### PR TITLE
Get rid of all build warnings

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
 - [ ] My contribution is **ready to be merged** as is
 - [ ] I verified the modifications **render properly**
 - [ ] I used **spell checking**
-- [ ] I introduced **no new warnings** during build or declared them here
+- [ ] I introduced **no warnings** during build (`make -j8 clean html`)
 - [ ] I **used the styling and structure aids available** in [Sphinx/ResT](http://www.sphinx-doc.org/en/stable/rest.html). (Links use `` `…`_``, enumerations `#.`, lists `*`, code ``` ``…`` ```/`.. code::`, warnings .. `warning::`, etc.)
 - [ ] I reread the text keeping in mind that the text has to be **comprehended** fully **by the target audience**
 

--- a/conf.py
+++ b/conf.py
@@ -350,7 +350,7 @@ texinfo_documents = [
 intersphinx_mapping = {'https://docs.python.org/': None}
 
 # added to all *.rst files
-rst_epilog = ".. include:: /global.rst"
+rst_epilog = "\n.. include:: /global.rst"
 
 # add custom style sheet
 def setup(app):

--- a/conf.py
+++ b/conf.py
@@ -350,7 +350,7 @@ texinfo_documents = [
 intersphinx_mapping = {'https://docs.python.org/': None}
 
 # added to all *.rst files
-rst_prolog = ".. include:: /global.rst"
+rst_epilog = ".. include:: /global.rst"
 
 # add custom style sheet
 def setup(app):

--- a/devops/openshift/basics.rst
+++ b/devops/openshift/basics.rst
@@ -74,7 +74,7 @@ Every project consists of the following OpenShift elements:
 .. [#f1] Production systems use the ``production`` tag and test systems the ``test`` tag.
 .. [#f2] By default the ``stable`` tag is used. ``latest`` is the staging area and is only deployed on selected systems.
 .. [#f3] Mounted at ``/persist`` and only the subdirectory ``/persist/index_data`` is currently used for the :term:`Solr` index.
-.. [#f4] Image source is hosted on `Github <https://github.com/tocco/openshift-nginx>`_ and the ``latest`` tag is
+.. [#f4] Image source is hosted on `Github <https://github.com/tocco/openshift-nginx>`__ and the ``latest`` tag is
          automatically built on `Dockerhub <https://hub.docker.com/r/toccoag/openshift-nginx/>`__.
-.. [#f5] Image source is hosted on `Github <https://github.com/tocco/openshift-solr>`_ and the ``latest`` tag is
+.. [#f5] Image source is hosted on `Github <https://github.com/tocco/openshift-solr>`__ and the ``latest`` tag is
          automatically built on `Dockerhub <https://hub.docker.com/r/toccoag/openshift-solr/>`__.

--- a/glossary.rst
+++ b/glossary.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Glossary
 ========
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is **ready to be merged** as is
- [x] I verified the modifications **render properly**
- [x] I used **spell checking**
- [x] I introduced **no new warnings** during build or declared them here
- [x] I **used the styling and structure aids available** in [Sphinx/ResT](http://www.sphinx-doc.org/en/stable/rest.html). (Links use `` `…`_``, enumerations `#.`, lists `*`, code ``` ``…`` ```/`.. code::`, warnings .. `warning::`, etc.)
- [x] I reread the text keeping in mind that the text has to be **comprehended** fully **by the target audience**

### Description
• move include to epilog (interferes with :orphan:)
• declare global.rst an :orphan: (not referenced in toctree)
• resolve conflicting target names
