### PR TITLE
Correct restore command for gzipped files

### DIFF
--- a/devops/databases/copy_database.rst
+++ b/devops/databases/copy_database.rst
@@ -28,7 +28,7 @@ Restore Database
 
     .. code-block:: bash
 
-        gzip -cd ${DUMP_FILE_PATH} | PGOPTIONS="-c synchronous_commit=off" pg_restore -j 4 -U postgres -h ${DB_SERVER} --role ${DB_USER} --no-owner --no-acl -d ${DB_NAME}
+        gzip -cd ${DUMP_FILE_PATH} | PGOPTIONS="-c synchronous_commit=off" pg_restore -U postgres -h ${DB_SERVER} --role ${DB_USER} --no-owner --no-acl -d ${DB_NAME}
 
 .. hint::
 


### PR DESCRIPTION
`-j N` isn't supported for streams.

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is **ready to be merged** as is
- [x] I verified the modifications **render properly**
- [x] I used **spell checking**
- [x] I **used the styling and structure aids available** in [Sphinx/ResT](http://www.sphinx-doc.org/en/stable/rest.html). (Links use `` `…`_``, enumerations `#.`, lists `*`, code ``` ``…`` ```/`.. code::`, warnings .. `warning::`, etc.)
- [x] I reread the text keeping in mind that the text has to be **comprehended** fully **by the target audience**

### Description
<!-- brief description of the changes you made -->
