### PR TITLE
Stop using font-weight bold for color roles

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -9,15 +9,12 @@ div.figure img {
 
 .blue {
     color: blue;
-    font-weight: bold;
 }
 
 .green {
     color: green;
-    font-weight: bold;
 }
 
 .red {
     color: red;
-    font-weight: bold;
 }


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is **ready to be merged** as is
- [x] I verified the modifications **render properly**
- [x] I used **spell checking**
- [x] I **used the styling and structure aids available** in [Sphinx/ResT](http://www.sphinx-doc.org/en/stable/rest.html). (Links use `` `…`_``, enumerations `#.`, lists `*`, code ``` ``…`` ```/`.. code::`, warnings .. `warning::`, etc.)
- [x] I reread the text keeping in mind that the text has to be **comprehended** fully **by the target audience**

### Description
<!-- brief description of the changes you made -->
Using bold leads to misallignment in monospaced text. So, stop
using it.