### PR TITLE
Show exact command for enabling memory dumps

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -18,3 +18,9 @@ div.figure img {
 .red {
     color: red;
 }
+
+pre.literal-block {
+    font-size: 12px;
+    line-height: normal;
+    padding: 12px !important;
+}

--- a/devops/nice/thread_and_memory_dumps.rst
+++ b/devops/nice/thread_and_memory_dumps.rst
@@ -74,7 +74,12 @@ Creating Memory Dump on OOM
 
 #. add persistent volume for dumps
 
-   Create an appropriately sized volume for ``/app/var/heap_dumps`` as described in :ref:`persistent-volume-creation`.
+   Create an appropriately sized volume for ``/app/var/heap_dumps``. Increase the size (**5G** in the example below)
+   if necessary:
+
+   .. parsed-literal::
+
+       oc volume dc/nice -c nice --add --name=oom --claim-name=oom --claim-size=\ **5G** --mount-path=/app/var/heap_dumps
 
 #. wait for OOM crash
 
@@ -113,5 +118,13 @@ Creating Memory Dump on OOM
 
 #. remove persistent volume for dumps
 
-    Remove previously created persistent volume for ``/app/var/heap_dumps`` as outlined in
-    :ref:`persistent-volume-removal`.
+    Remove previously created persistent volume for ``/app/var/heap_dumps``
+
+    .. code::
+
+        oc volume dc/nice -c nice --remove --name=oom
+        oc delete pvc oom
+
+    .. warning::
+
+        This will restart Nice automatically!

--- a/devops/nice/thread_and_memory_dumps.rst
+++ b/devops/nice/thread_and_memory_dumps.rst
@@ -118,7 +118,7 @@ Creating Memory Dump on OOM
 
 #. remove persistent volume for dumps
 
-    Remove previously created persistent volume for ``/app/var/heap_dumps``
+    Remove previously created persistent volume for ``/app/var/heap_dumps``:
 
     .. code::
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is **ready to be merged** as is
- [x] I verified the modifications **render properly**
- [x] I used **spell checking**
- [x] I **used the styling and structure aids available** in [Sphinx/ResT](http://www.sphinx-doc.org/en/stable/rest.html). (Links use `` `…`_``, enumerations `#.`, lists `*`, code ``` ``…`` ```/`.. code::`, warnings .. `warning::`, etc.)
- [x] I reread the text keeping in mind that the text has to be **comprehended** fully **by the target audience**

### Description
<!-- brief description of the changes you made -->

* Show exact commands for enabling memory dumps for lazy people like me.
* Make literal blocks look more like code blocks (smaller font in particular)
