### PR TITLE
Add live reload for more comfortable local editing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,3 +223,6 @@ dummy:
 	$(SPHINXBUILD) -b dummy $(ALLSPHINXOPTS) $(BUILDDIR)/dummy
 	@echo
 	@echo "Build finished. Dummy builder generates no files."
+
+livehtml:
+	sphinx-autobuild -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
 	@echo "  html       to make standalone HTML files"
+	@echo "  livehtml   to make standalone HTML files and reload them automatically while you type"
 	@echo "  dirhtml    to make HTML files named index.html in directories"
 	@echo "  singlehtml to make a single large HTML file"
 	@echo "  pickle     to make pickle files"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,22 @@ You need tho have this dependency installed:
 Now you can build the documentation using:
 
 ```
-    make html
+make html
 ```
 
-the generated file can be found in `_build/html/`.
+The generated file can be found in `_build/html/`.
+
+### Live reload while you type
+
+Install `sphinx-autobuild`:
+```
+pip install --user sphinx-autobuild
+```
+
+Then run with:
+```
+make livehtml
+```
+
+And then visit the webpage served at http://127.0.0.1:8000. Each time a change to the documentation source is detected,
+the HTML is rebuilt and the browser automatically reloaded.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Now you can build the documentation using:
 make html
 ```
 
-The generated file can be found in `_build/html/`.
+The generated files can be found in `_build/html/`.
 
 ### Live reload while you type
 
@@ -35,4 +35,4 @@ make livehtml
 ```
 
 And then visit the webpage served at http://127.0.0.1:8000. Each time a change to the documentation source is detected,
-the HTML is rebuilt and the browser automatically reloaded.
+the HTML is rebuilt and the page automatically reloaded.


### PR DESCRIPTION
- Requires `sphinx-autobuild`
- Once `sphinx-autobuild` is installed, run it with `make livehtml`
  and open the browser at http://127.0.0.1:8000 -> rebuilt and reloaded
  on each change in the source files

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is **ready to be merged** as is
- [x] I verified the modifications **render properly**
- [x] I used **spell checking**
- [x] I **used the styling and structure aids available** in [Sphinx/ResT](http://www.sphinx-doc.org/en/stable/rest.html). (Links use `` `…`_``, enumerations `#.`, lists `*`, code ``` ``…`` ```/`.. code::`, warnings .. `warning::`, etc.)
- [x] I reread the text keeping in mind that the text has to be **comprehended** fully **by the target audience**

### Description
<!-- brief description of the changes you made -->
