### PR TITLE
Insert warning in remote debugging page: only suspend thread

### DIFF
--- a/devops/nice/remote_debugging.rst
+++ b/devops/nice/remote_debugging.rst
@@ -1,6 +1,11 @@
 Remote Debugging of Nice2
 =========================
 
+.. warning::
+
+   Always make sure you select **Suspend -> Thread** for breakpoints in IDEA,
+   so that you don't freeze the whole application during your debugging session.
+
 #. forward the debugging port to your machine
 
     **on OpenShift**:


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is **ready to be merged** as is
- [x] I verified the modifications **render properly**
- [x] I used **spell checking**
- [x] I **used the styling and structure aids available** in [Sphinx/ResT](http://www.sphinx-doc.org/en/stable/rest.html). (Links use `` `…`_``, enumerations `#.`, lists `*`, code ``` ``…`` ```/`.. code::`, warnings .. `warning::`, etc.)
- [x] I reread the text keeping in mind that the text has to be **comprehended** fully **by the target audience**

### Description
<!-- brief description of the changes you made -->
