### PR TITLE
Update instructions for Burp

### DIFF
--- a/devops/backups/database.rst
+++ b/devops/backups/database.rst
@@ -39,7 +39,7 @@ List Available Archives
 
 .. parsed-literal::
 
-      $ sudo burp -C db2.tocco.cust.vshn.net -a list
+      $ sudo burp -c /etc/burp/slave.conf -C db2.tocco.cust.vshn.net -a list
       Backup: 0000155 2018-01-31 03:03:22 +0100 (deletable)
       Backup: 0000162 2018-02-09 01:14:05 +0100 (deletable)
       Backup: :green:`0000169` 2018-02-16 01:10:54 +0100 (deletable)
@@ -54,7 +54,7 @@ Show the content of directory ``/var/lib/postgresql-backup/`` in archive :green:
 
 .. parsed-literal::
 
-      $ sudo burp -C db2.tocco.cust.vshn.net -a list -b :green:`0000169` -r '^/var/lib/postgresql-backup/'
+      $ sudo burp -c /etc/burp/slave.conf -C db2.tocco.cust.vshn.net -a list -b :green:`0000169` -r '^/var/lib/postgresql-backup/'
       Backup: 0000169 2018-02-16 01:10:54 +0100 (deletable)
       With regex: ^/var/lib/postgresql-backup/
       /var/lib/postgresql-backup/postgres-nice_awpf.dump.gz
@@ -73,7 +73,7 @@ Restore **postgres-nice_bnftest.dump.gz** from backup :green:`0000169` to direct
 .. parsed-literal::
 
       $ mkdir -p :blue:`~/restores/`
-      $ sudo burp -C db2.tocco.cust.vshn.net -a restore -b :green:`0000169` -d :blue:`~/restores/` -r '^\ :red:`/var/lib/postgresql-backup/postgres-nice_bnftest.dump.gz`'
+      $ sudo burp -c /etc/burp/slave.conf -C db2.tocco.cust.vshn.net -a restore -b :green:`0000169` -d :blue:`~/restores/` -r '^\ :red:`/var/lib/postgresql-backup/postgres-nice_bnftest.dump.gz`'
       …
       2018-03-09 16:01:30 +0100: burp[23156] restore finished
       $ ls -lh :blue:`~/restores/`:red:`var/lib/postgresql-backup/postgres-nice_bnftest.dump.gz`


### PR DESCRIPTION
Syntax for accessing backups on db1 made on db2 changed.

See: https://control.vshn.net/tickets/TOCO-130

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is **ready to be merged** as is
- [x] I verified the modifications **render properly**
- [x] I used **spell checking**
- [x] I **used the styling and structure aids available** in [Sphinx/ResT](http://www.sphinx-doc.org/en/stable/rest.html). (Links use `` `…`_``, enumerations `#.`, lists `*`, code ``` ``…`` ```/`.. code::`, warnings .. `warning::`, etc.)
- [x] I reread the text keeping in mind that the text has to be **comprehended** fully **by the target audience**