### PR TITLE
Update section about DB restores

### DIFF
--- a/devops/databases/copy_database.rst
+++ b/devops/databases/copy_database.rst
@@ -18,17 +18,25 @@ Dump Database
 Restore Database
 ----------------
 
-**\*.psql** files:
+.. important::
+
+   Restore must be made into an **empty** database:
+
+   .. parsed-literal::
+
+       CREATE DATABASE **${DB_NAME}** WITH OWNER **${DB_USER}**;
+
+**\*.psql** and **\*.dump** files:
 
     .. code-block:: bash
 
-        PGOPTIONS="-c synchronous_commit=off" pg_restore -j 4 -U postgres -h ${DB_SERVER} --role ${DB_USER} --no-owner --no-acl -d ${DB_NAME} ${DUMP_FILE_PATH}
+        pg_restore -j 4 -U postgres -h ${DB_SERVER} --role ${DB_USER} --no-owner --no-acl -d ${DB_NAME} ${DUMP_FILE_PATH}
 
 **\*.dump.gz** files:
 
     .. code-block:: bash
 
-        gzip -cd ${DUMP_FILE_PATH} | PGOPTIONS="-c synchronous_commit=off" pg_restore -U postgres -h ${DB_SERVER} --role ${DB_USER} --no-owner --no-acl -d ${DB_NAME}
+        gzip -cd ${DUMP_FILE_PATH} | pg_restore -U postgres -h ${DB_SERVER} --role ${DB_USER} --no-owner --no-acl -d ${DB_NAME}
 
 .. hint::
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is **ready to be merged** as is
- [x] I verified the modifications **render properly**
- [x] I used **spell checking**
- [x] I **used the styling and structure aids available** in [Sphinx/ResT](http://www.sphinx-doc.org/en/stable/rest.html). (Links use `` `…`_``, enumerations `#.`, lists `*`, code ``` ``…`` ```/`.. code::`, warnings .. `warning::`, etc.)
- [x] I reread the text keeping in mind that the text has to be **comprehended** fully **by the target audience**

### Description
• Remove synchronous_commit=off, this is now default on all clusters.
• Add *.dump glob since that sometimes used instead of *.psql.
• Mention that a restores need to be made into an empty database.
