### PR TITLE
Replace deprecated `oc volume` with `oc set volume`

### DIFF
--- a/devops/nice/configuration.rst
+++ b/devops/nice/configuration.rst
@@ -204,7 +204,7 @@ This creates a :term:`PVC` of size 1 GiB called ``cms`` which is mounted in the 
 
 .. code::
 
-    oc volume dc/nice -c nice --add --name=cms --claim-name=cms --claim-size=1G --mount-path=/app/var/cms
+    oc set volume dc/nice -c nice --add --name=cms --claim-name=cms --claim-size=1G --mount-path=/app/var/cms
 
 You can list the PVCs using ``oc get pvc`` and you'll see the mounted volumes in the deployment config
 using ``oc describe dc ${POD}``, section *Mount*.
@@ -241,5 +241,5 @@ First remove the volume from the container. Then, remove the actual :term:`PVC`.
 
 .. code::
 
-        oc volume dc/nice -c nice --remove --name=cms
+        oc set volume dc/nice -c nice --remove --name=cms
         oc delete pvc cms

--- a/devops/nice/thread_and_memory_dumps.rst
+++ b/devops/nice/thread_and_memory_dumps.rst
@@ -79,7 +79,7 @@ Creating Memory Dump on OOM
 
    .. parsed-literal::
 
-       oc volume dc/nice -c nice --add --name=oom --claim-name=oom --claim-size=\ **5G** --mount-path=/app/var/heap_dumps
+       oc set volume dc/nice -c nice --add --name=oom --claim-name=oom --claim-size=\ **5G** --mount-path=/app/var/heap_dumps
 
 #. wait for OOM crash
 
@@ -122,7 +122,7 @@ Creating Memory Dump on OOM
 
     .. code::
 
-        oc volume dc/nice -c nice --remove --name=oom
+        oc set volume dc/nice -c nice --remove --name=oom
         oc delete pvc oom
 
     .. warning::


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is **ready to be merged** as is
- [x] I verified the modifications **render properly**
- [x] I used **spell checking**
- [x] I **used the styling and structure aids available** in [Sphinx/ResT](http://www.sphinx-doc.org/en/stable/rest.html). (Links use `` `…`_``, enumerations `#.`, lists `*`, code ``` ``…`` ```/`.. code::`, warnings .. `warning::`, etc.)
- [x] I reread the text keeping in mind that the text has to be **comprehended** fully **by the target audience**