### PR TITLE
Stop telling people to use '__' and '___' instead of '.' and '-'

### DIFF
--- a/devops/databases/remote_access.rst
+++ b/devops/databases/remote_access.rst
@@ -33,11 +33,11 @@ Obtain credentials:
 
         $ oc project toco-nice-**${INSTALLATION}**
         $ oc set env --list dc/nice \|grep ^NICE2_HIKARI_dataSource
-        NICE2_HIKARI_dataSource__databaseName=\ :green:`nice_tocco`
-        NICE2_HIKARI_dataSource__password=\ :red:`DAPVK11Zt9X1PtVv9ily`
-        NICE2_HIKARI_dataSource__serverName=db1.tocco.cust.vshn.net
-        NICE2_HIKARI_dataSource__user=\ :blue:`nice_tocco`
-        NICE2_HIKARI_dataSource__sslMode=require
+        NICE2_HIKARI_dataSource.databaseName=\ :green:`nice_tocco`
+        NICE2_HIKARI_dataSource.password=\ :red:`DAPVK11Zt9X1PtVv9ily`
+        NICE2_HIKARI_dataSource.serverName=db1.tocco.cust.vshn.net
+        NICE2_HIKARI_dataSource.user=\ :blue:`nice_tocco`
+        NICE2_HIKARI_dataSource.sslMode=require
 
 Now create or alter ``customer/${CUSTOMER}/etc/hikaricp.local.properties``:
 

--- a/devops/nice/configuration.rst
+++ b/devops/nice/configuration.rst
@@ -92,15 +92,15 @@ The env section looks something like this:
     containers:
       - name: nice
         env:
-        - name: NICE2_HIKARI_dataSource__databaseName
+        - name: NICE2_HIKARI_dataSource.databaseName
           value: nice_pege
-        - name: NICE2_HIKARI_dataSource__serverName
+        - name: NICE2_HIKARI_dataSource.serverName
           value: postgresqlssd
-        - name: NICE2_HIKARI_dataSource__user
+        - name: NICE2_HIKARI_dataSource.user
           value: nice_pege
-        - name: NICE2_JAVA_OPT____Dch__tocco__nice2__runenv
+        - name: NICE2_JAVA_OPT_-Dch.tocco.nice2.runenv
           value: production
-        - name: NICE2_APP_nice2__enterprisesearch__solrUrl
+        - name: NICE2_APP_nice2.enterprisesearch.solrUrl
           value: http://solr:8983/solr/nice2_index
 
 
@@ -113,24 +113,11 @@ NICE2_JAVA_PARAM_*   Pass custom parameters to Java.
 NICE2_NICE_ARG_*     Pass custom argument to Nice. (Not applied in :term:`pre-hook pod`)
 ===================  ===================================================================================================
 
-.. important::
+.. hint::
 
-    OpenShift does not currently allow ``.`` (period) or ``-`` (hyphen) to appear as key of an environment variable.
-    [#f2]_
-
-    As workaround:
-
-        ==============  ===========================
-        instead of      use
-        ==============  ===========================
-        ``.`` (period)  ``__`` (double underscore)
-        ``-`` (hyphen)  ``___`` (triple underscore)
-        ==============  ===========================
-
-    For instance, instead of:
-        ``NICE2_JAVA_OPT_-Dch.tocco.nice2.runenv=production``
-    use:
-        ``NICE2_JAVA_OPT____Dch__tocco__nice2__runenv=production`` [#f1]_
+   In some places, you may still find `__` used instead of `.` and `___` used instead
+   of `-`. This because older OpenShift versions didn't allow these characters to
+   appear in the name of an environment variable. [#f2]_
 
 Examples
 ````````

--- a/devops/nice/install_ldap.rst
+++ b/devops/nice/install_ldap.rst
@@ -59,7 +59,7 @@ Adjust the Deployment Config
 
 .. code::
 
-   oc set env dc/nice NICE2_APP_nice2__optional__ldapserver__enabled="true" NICE2_APP_nice2__optional__ldapserver__port="10389" NICE2_APP_nice2__optional__ldapserver__certificatePassword="${CERTIFICATE_PASSWORD}" NICE2_APP_nice2__optional__ldapserver__keyStoreFile="/persist/${KEYFILE}"
+   oc set env dc/nice NICE2_APP_nice2.optional.ldapserver.enabled="true" NICE2_APP_nice2.optional.ldapserver.port="10389" NICE2_APP_nice2.optional.ldapserver.certificatePassword="${CERTIFICATE_PASSWORD}" NICE2_APP_nice2.optional.ldapserver.keyStoreFile="/persist/${KEYFILE}"
 
 2. Mount the Secret into the nice Container
 

--- a/devops/openshift/nice2_and_docker.rst
+++ b/devops/openshift/nice2_and_docker.rst
@@ -129,7 +129,7 @@ Running the Image Locally
     docker run --rm -p 8080:8080 -e NICE2_HIKARI_dataSource.serverName=\ **${DB_SERVER}** \\
       -e NICE2_LOGBACK_CONFIG=\ **logback_terminal** -e NICE2_HIKARI_dataSource.databaseName=\ **${DB_NAME}** \\
       -e NICE2_HIKARI_dataSource.user=\ **${DB_USER}** -e NICE2_HIKARI_dataSource.password=\ **${DB_PASSWORD}** \\
-      -e NICE2_JAVA_OPT\_-Dch.tocco.nice2.runenv=\ **development** -e NICE2_HIKARI_dataSource__sslMode=require \\
+      -e NICE2_JAVA_OPT\_-Dch.tocco.nice2.runenv=\ **development** -e NICE2_HIKARI_dataSource.sslMode=require \\
       **${DOCKER_IMAGE_NAME}**
 
 .. hint::
@@ -137,7 +137,7 @@ Running the Image Locally
    If you run Postgres in a Docker container called *pg*, as described below, use this to link the Nice container to it::
 
        -e NICE2_HIKARI_dataSource.serverName=pg -e NICE2_HIKARI_dataSource.user=nice \
-       -e NICE2_HIKARI_dataSource.password=nice -e NICE2_HIKARI_dataSource__sslMode=disable --link pg
+       -e NICE2_HIKARI_dataSource.password=nice -e NICE2_HIKARI_dataSource.sslMode=disable --link pg
 
    Linking container ``pg`` (``--link pg``) makes the container available with the host name ``pg`` within the Nice container.
 
@@ -195,7 +195,7 @@ but execute the ``dbref`` command within the container.
     docker run --rm -p 8080:8080 -e NICE2_HIKARI_dataSource.serverName=${DB_SERVER} \\
       -e NICE2_LOGBACK_CONFIG=logback_terminal -e NICE2_HIKARI_dataSource.databaseName=${DB_NAME} \\
       -e NICE2_HIKARI_dataSource.user=${DB_USER} -e NICE2_HIKARI_dataSource.password=${DB_PASSWORD} \\
-      -e NICE2_JAVA_OPT\_-Dch.tocco.nice2.runenv=development -e NICE2_HIKARI_dataSource__sslMode=require \\
+      -e NICE2_JAVA_OPT\_-Dch.tocco.nice2.runenv=development -e NICE2_HIKARI_dataSource.sslMode=require \\
       ${DOCKER_IMAGE_NAME} **dbref**
 
 

--- a/devops/solr/move_openshift_vm.rst
+++ b/devops/solr/move_openshift_vm.rst
@@ -112,7 +112,7 @@ Move Solr Core from OpenShift to a Managed Server
 
     .. parsed-literal::
 
-       oc set env dc/nice -c nice NICE2_APP_nice2__enterprisesearch__solrUrl=https://solr\ **${N}**.tocco.cust.vshn.net:8983/solr/nice-**${INSTALLATION}**
+       oc set env dc/nice -c nice NICE2_APP_nice2.enterprisesearch.solrUrl=https://solr\ **${N}**.tocco.cust.vshn.net:8983/solr/nice-**${INSTALLATION}**
 
 #. Stop Solr on OpenShift
 

--- a/error_database/database.rst
+++ b/error_database/database.rst
@@ -156,10 +156,10 @@ First, you need to figure out why there aren't enough connections around. For th
            .. parsed-literal::
 
                $ oc set env dc/nice --list -c nice | grep '^NICE2_HIKARI_'
-               NICE2_HIKARI_dataSource__databaseName=nice_toccotest
-               NICE2_HIKARI_dataSource__password=************
-               NICE2_HIKARI_dataSource__serverName=db1.tocco.cust.vshn.net
-               NICE2_HIKARI_dataSource__user=nice_toccotest
+               NICE2_HIKARI_dataSource.databaseName=nice_toccotest
+               NICE2_HIKARI_dataSource.password=************
+               NICE2_HIKARI_dataSource.serverName=db1.tocco.cust.vshn.net
+               NICE2_HIKARI_dataSource.user=nice_toccotest
                **NICE2_HIKARI_maximumPoolSize**\ =12
                NICE2_HIKARI_leakDetectionThreshold=30000
 

--- a/error_database/db_refactoring.rst
+++ b/error_database/db_refactoring.rst
@@ -26,7 +26,7 @@ Solution
 
            .. parsed-literal::
 
-                - name: NICE2_APP_nice2__dbrefactoring__businessunits
+                - name: NICE2_APP_nice2.dbrefactoring.businessunits
                   value: **bu1,bu2,…**
 
 Full Error Message


### PR DESCRIPTION
'-' and '.' are now allowed to appear in env. variable names.

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is **ready to be merged** as is
- [x] I verified the modifications **render properly**
- [x] I used **spell checking**
- [x] I **used the styling and structure aids available** in [Sphinx/ResT](http://www.sphinx-doc.org/en/stable/rest.html). (Links use `` `…`_``, enumerations `#.`, lists `*`, code ``` ``…`` ```/`.. code::`, warnings .. `warning::`, etc.)
- [x] I reread the text keeping in mind that the text has to be **comprehended** fully **by the target audience**

Closes #215 