### PR TITLE
update initial values documentation after migration

### DIFF
--- a/framework/configuration/initial-values.rst
+++ b/framework/configuration/initial-values.rst
@@ -109,7 +109,7 @@ extension
 """""""""
 
 Set this to ``true`` if you need to extend an existing initial value from another module. A usual use case will be to
-add values for fields or relations that have been added in later modules. To extend another value, the ref:`identifier`
+add values for fields or relations that have been added in later modules. To extend another value, the :ref:`identifier`
 configuration and the identifier value itself of the source and extension value need to match.
 
 You are able to overwrite values form the source, but use this with caution. There is no guarantee for a deterministic


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is **ready to be merged** as is
- [x] I verified the modifications **render properly**
- [x] I used **spell checking**
- [x] I **used the styling and structure aids available** in [Sphinx/ResT](http://www.sphinx-doc.org/en/stable/rest.html). (Links use `` `…`_``, enumerations `#.`, lists `*`, code ``` ``…`` ```/`.. code::`, warnings .. `warning::`, etc.)
- [x] I reread the text keeping in mind that the text has to be **comprehended** fully **by the target audience**

### Description
Adjusted the initial value documentation based on changes and findings from the migration of our standard modules to the new format.
