### PR TITLE
Move from javasphinx (no longer supported) to extlinks

### DIFF
--- a/about.rst
+++ b/about.rst
@@ -15,14 +15,12 @@ You need tho have this dependency installed:
 * python3-sphinx
 * python3-sphinx-rtd-theme
 * graphviz
-* javasphinx (`pip3 install --user javasphinx`)
 * python3-sphinx-autobuild (optional, needed for live reload)
 
 On Debian-based Linux, dependencies can be installed like this::
 
-    apt install python3 python3-sphinx-rtd-theme graphviz pip3
+    apt install python3 python3-sphinx-rtd-theme graphviz
     apt install python3-sphinx-autobuild  # optional, needed for live reload
-    pip3 install --user javasphinx
 
 
 Build the documentation

--- a/conf.py
+++ b/conf.py
@@ -355,7 +355,7 @@ rst_prolog = ".. include:: /global.rst\n\n"
 
 # add custom style sheet
 def setup(app):
-    app.add_stylesheet("css/custom.css")
+    app.add_css_file("css/custom.css")
 
 extlinks = {
    'ticket': ('https://control.vshn.net/tickets/%s', ''),

--- a/conf.py
+++ b/conf.py
@@ -34,7 +34,6 @@ extensions = [
     'sphinx.ext.graphviz',
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
-    'javasphinx'
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -358,16 +357,15 @@ rst_prolog = ".. include:: /global.rst\n\n"
 def setup(app):
     app.add_stylesheet("css/custom.css")
 
-javadoc_url_map = {
-    'org.hibernate' : ('https://docs.jboss.org/hibernate/orm/5.4/javadocs/', 'javadoc'),
-    'javassist' : ('https://jboss-javassist.github.io/javassist/html', 'javadoc')
-}
-
 extlinks = {
    'ticket': ('https://control.vshn.net/tickets/%s', ''),
    'vshn': ('https://control.vshn.net/tickets/%s', ''),
    'ansible-repo-file': ('https://git.tocco.ch/gitweb?p=ansible.git;a=blob;f=%s', '/'),
    'ansible-repo-dir': ('https://git.tocco.ch/gitweb?p=ansible.git;a=blob;a=tree;f=%s', '/'),
    'hierra-repo': ('https://git.vshn.net/tocco/tocco_hieradata/blob/master/%s', ''),
-   'tocco-manual': ('https://223.docs.tocco.ch/en/%s', None)
+   'tocco-manual': ('https://223.docs.tocco.ch/en/%s', ''),
+   'java': ('https://docs.oracle.com/en/java/javase/11/docs/api/java.base/%s.html', ''),
+   'java-hibernate': ('https://docs.jboss.org/hibernate/orm/5.4/javadocs/%s', ''),
+   'java-javax': ('https://javaee.github.io/javaee-spec/javadocs/%s', ''),
+   'java-javassist': ('https://www.javassist.org/html/%s', ''),
 }

--- a/devops/openshift/nice2_and_docker.rst
+++ b/devops/openshift/nice2_and_docker.rst
@@ -47,7 +47,7 @@ Pull a Docker Image from VSHN's Registry
 
    .. hint::
    
-      An ``oc describe …`` on :term:`RC`\ s and :term:`Pod`\ s will also reveal the used images.
+      An ``oc describe …`` on :term:`RC`\ s and :term:`pod`\ s will also reveal the used images.
    
       :term:`Solr` and :term:`Nginx` images can be found in the project ``toco-shared-imagestreams``.
 

--- a/framework/architecture/acl/tests.rst
+++ b/framework/architecture/acl/tests.rst
@@ -2,7 +2,7 @@ Tests
 =====
 
 The easiest way to test the ACL rules of a module is by extending
-:java:ref:`ch.tocco.nice2.persist.security.inject.AbstractModuleAclTest`. This base test class automatically sets the
+:abbr:`ch.tocco.nice2.persist.security.inject.AbstractModuleAclTest (AbstractModuleAclTest)`. This base test class automatically sets the
 ``entity.acl`` file of the current module as initial policy for the tests.
 
 
@@ -71,7 +71,7 @@ See the following example for the `nice2-optional-correspondence` module:
 Test methods
 ------------
 
-Among others, :java:ref:`ch.tocco.nice2.persist.security.inject.AbstractModuleAclTest` provides the following useful methods:
+Among others, :abbr:`ch.tocco.nice2.persist.security.inject.AbstractModuleAclTest (AbstractModuleAclTest)` provides the following useful methods:
 
 * `baseTestCase(ExpectedAccess expectedAccess, Principal principal, Callable<Entity> dataCreator, String... fields)`
 * `baseTestCase(List<String> aclFileNames, ExpectedAccess expectedAccess, Principal principal, Callable<Entity> dataCreator, String... fields)`

--- a/framework/architecture/acl/tests.rst
+++ b/framework/architecture/acl/tests.rst
@@ -2,7 +2,7 @@ Tests
 =====
 
 The easiest way to test the ACL rules of a module is by extending
-:abbr:`ch.tocco.nice2.persist.security.inject.AbstractModuleAclTest (AbstractModuleAclTest)`. This base test class automatically sets the
+:abbr:`AbstractModuleAclTest (ch.tocco.nice2.persist.security.inject.AbstractModuleAclTest)`. This base test class automatically sets the
 ``entity.acl`` file of the current module as initial policy for the tests.
 
 
@@ -71,7 +71,7 @@ See the following example for the `nice2-optional-correspondence` module:
 Test methods
 ------------
 
-Among others, :abbr:`ch.tocco.nice2.persist.security.inject.AbstractModuleAclTest (AbstractModuleAclTest)` provides the following useful methods:
+Among others, :abbr:`AbstractModuleAclTest (ch.tocco.nice2.persist.security.inject.AbstractModuleAclTest)` provides the following useful methods:
 
 * `baseTestCase(ExpectedAccess expectedAccess, Principal principal, Callable<Entity> dataCreator, String... fields)`
 * `baseTestCase(List<String> aclFileNames, ExpectedAccess expectedAccess, Principal principal, Callable<Entity> dataCreator, String... fields)`

--- a/framework/architecture/businessunit/hierarchical-business-units.rst
+++ b/framework/architecture/businessunit/hierarchical-business-units.rst
@@ -152,12 +152,12 @@ Technical implementation
 Hierachical business units actually do not have anything to do with the with business unit handling itself. It is more
 something built on top of the business unit.
 
-The read and write permissions are handled by the :java:ref:`ch.tocco.nice2.businessunit.impl.hierarchy.GenericHierarchyPolicyProcessor`.
-This policy processor adds rules (:java:ref:`ch.tocco.nice2.security.Rule`) depending on the contributed
-:java:ref:`ch.tocco.nice2.businessunit.impl.hierarchy.HierarchySpecification` during the login phase.
+The read and write permissions are handled by the :abbr:`ch.tocco.nice2.businessunit.impl.hierarchy.GenericHierarchyPolicyProcessor (GenericHierarchyPolicyProcessor)`.
+This policy processor adds rules (:abbr:`ch.tocco.nice2.security.Rule (Rule)`) depending on the contributed
+:abbr:`ch.tocco.nice2.businessunit.impl.hierarchy.HierarchySpecification (HierarchySpecification)` during the login phase.
 
 The rules are actually created by the handlers for the different strategies (`self`, `hierarchical`) which are provided
-by the :java:ref:`ch.tocco.nice2.businessunit.impl.hierarchy.strategies.HierarchyStrategyProvider`.
+by the :abbr:`ch.tocco.nice2.businessunit.impl.hierarchy.strategies.HierarchyStrategyProvider (HierarchyStrategyProvider)`.
 
 Miscellaneous
 -------------

--- a/framework/architecture/businessunit/hierarchical-business-units.rst
+++ b/framework/architecture/businessunit/hierarchical-business-units.rst
@@ -152,12 +152,12 @@ Technical implementation
 Hierachical business units actually do not have anything to do with the with business unit handling itself. It is more
 something built on top of the business unit.
 
-The read and write permissions are handled by the :abbr:`ch.tocco.nice2.businessunit.impl.hierarchy.GenericHierarchyPolicyProcessor (GenericHierarchyPolicyProcessor)`.
-This policy processor adds rules (:abbr:`ch.tocco.nice2.security.Rule (Rule)`) depending on the contributed
-:abbr:`ch.tocco.nice2.businessunit.impl.hierarchy.HierarchySpecification (HierarchySpecification)` during the login phase.
+The read and write permissions are handled by the :abbr:`GenericHierarchyPolicyProcessor (ch.tocco.nice2.businessunit.impl.hierarchy.GenericHierarchyPolicyProcessor)`.
+This policy processor adds rules (:abbr:`Rule (ch.tocco.nice2.security.Rule)`) depending on the contributed
+:abbr:`HierarchySpecification (ch.tocco.nice2.businessunit.impl.hierarchy.HierarchySpecification)` during the login phase.
 
 The rules are actually created by the handlers for the different strategies (`self`, `hierarchical`) which are provided
-by the :abbr:`ch.tocco.nice2.businessunit.impl.hierarchy.strategies.HierarchyStrategyProvider (HierarchyStrategyProvider)`.
+by the :abbr:`HierarchyStrategyProvider (ch.tocco.nice2.businessunit.impl.hierarchy.strategies.HierarchyStrategyProvider)`.
 
 Miscellaneous
 -------------

--- a/framework/architecture/hibernate/abstract-pojo-entity.rst
+++ b/framework/architecture/hibernate/abstract-pojo-entity.rst
@@ -1,18 +1,18 @@
 Abstract entity base class
 ==========================
 
-All (non-transient) entities inherit from :java:ref:`AbstractPojoEntity<ch.tocco.nice2.persist.hibernate.pojo.AbstractPojoEntity>`.
-This class provides all functionality required by the :java:ref:`Entity<ch.tocco.nice2.persist.entity.Entity>` interface.
+All (non-transient) entities inherit from :abbr:`AbstractPojoEntity (ch.tocco.nice2.persist.hibernate.pojo.AbstractPojoEntity)`.
+This class provides all functionality required by the :abbr:`Entity (ch.tocco.nice2.persist.entity.Entity)` interface.
 
 
 Primary Key
 -----------
 
-In hibernate the primary key is simply a property (typically a :java:extdoc:`Long<java.lang.Long>`) annotated
-with :java:extdoc:`Id<javax.persistence.Id>`. In the old API the primary key value was encapsulated behind the
-:java:ref:`PrimaryKey<ch.tocco.nice2.persist.entity.PrimaryKey>` interface.
+In hibernate the primary key is simply a property (typically a :java:`Long <java/lang/Long>`) annotated
+with :java-javax:`Id <javax/persistence/Id>`. In the old API the primary key value was encapsulated behind the
+:abbr:`PrimaryKey (ch.tocco.nice2.persist.entity.PrimaryKey)` interface.
 
-An instance of :java:ref:`PrimaryKey<ch.tocco.nice2.persist.entity.PrimaryKey>` is created when ``getKey()`` or ``requireKey()``
+An instance of :abbr:`PrimaryKey (ch.tocco.nice2.persist.entity.PrimaryKey)` is created when ``getKey()`` or ``requireKey()``
 is called for the first name. The key is cached so that always the same instance is returned, which is expected by
 some of the business code.
 
@@ -22,11 +22,11 @@ Accessing values
 PropertyAccessorService
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-The :java:ref:`PropertyAccessorServiceImpl<ch.tocco.nice2.persist.hibernate.pojo.PropertyAccessorServiceImpl>` efficiently
+The :abbr:`PropertyAccessorServiceImpl (ch.tocco.nice2.persist.hibernate.pojo.PropertyAccessorServiceImpl)` efficiently
 reads and writes entity properties.
 
 Different strategies are used depending on the property type. For all persistent properties, the calls are delegated
-to Hibernate's :java:extdoc:`EntityPersister<org.hibernate.persister.entity.EntityPersister>`.
+to Hibernate's :java-hibernate:`EntityPersister <org/hibernate/persister/entity/EntityPersister>`.
 
 Transient properties are manually accessed using reflection.
 
@@ -39,10 +39,10 @@ Reading values
 ^^^^^^^^^^^^^^
 
 All calls to the different ``Entity#getValue()`` methods are delegated to ``AbstractHibernateEntity#internalGetValue()``,
-where the actual field is resolved and read using the :java:ref:`PropertyAccessorService<ch.tocco.nice2.persist.hibernate.pojo.PropertyAccessorService>`.
+where the actual field is resolved and read using the :abbr:`PropertyAccessorService (ch.tocco.nice2.persist.hibernate.pojo.PropertyAccessorService)`.
 
 For backwards compatibility, the resulting value is passed to ``TypeManager#isolate()`` before it is returned
-(which creates a copy of :java:ref:`Binary<ch.tocco.nice2.persist.entity.Binary>` instances).
+(which creates a copy of :abbr:`Binary (ch.tocco.nice2.persist.entity.Binary)` instances).
 
 It is also attempted to convert the value to the requested type.
 
@@ -50,10 +50,10 @@ Writing values
 ^^^^^^^^^^^^^^
 
 All calls to the different ``Entity#setValue()`` methods are delegated to ``AbstractHibernateEntity#internalSetValue()``,
-where the actual field is resolved and updated using the :java:ref:`PropertyAccessorService<ch.tocco.nice2.persist.hibernate.pojo.PropertyAccessorService>`.
+where the actual field is resolved and updated using the :abbr:`PropertyAccessorService (ch.tocco.nice2.persist.hibernate.pojo.PropertyAccessorService)`.
 
 At first the value is converted to the required target type (if this is not already the case and a suitable
-:java:ref:`Converter<ch.tocco.nice2.types.spi.Converter>` exists).
+:abbr:`Converter (ch.tocco.nice2.types.spi.Converter)` exists).
 
 The resulting value is then compared to the old value - if they are the same, the method silently returns.
 After the value has been set, a ``EntityFacadeListener#entityChanging()`` event will be fired.
@@ -74,28 +74,28 @@ Resolving relations
 -------------------
 
 An association in hibernate is simply an instance of the referenced type (or a collection if it's a to-many relation).
-In the old API it was required to 'resolve' a relation ( ``Entity#resolve()`` ) to a :java:ref:`RelationQuery<ch.tocco.nice2.persist.query.RelationQuery>`.
-This relation query can then be executed to get an instance of :java:ref:`Relation<ch.tocco.nice2.persist.entity.Relation>`.
+In the old API it was required to 'resolve' a relation ( ``Entity#resolve()`` ) to a :abbr:`RelationQuery (ch.tocco.nice2.persist.query.RelationQuery)`.
+This relation query can then be executed to get an instance of :abbr:`Relation (ch.tocco.nice2.persist.entity.Relation)`.
 
 To-One relations
 ^^^^^^^^^^^^^^^^
 
 All to one associations are explicitly configured to be loaded lazily (JPA default is eager).
 
-:java:ref:`ToOneRelationQueryAdapter<ch.tocco.nice2.persist.hibernate.pojo.relation.ToOneRelationQueryAdapter>` is the
-implementation of :java:ref:`RelationQuery<ch.tocco.nice2.persist.query.RelationQuery>` used for to-one associations.
+:abbr:`ToOneRelationQueryAdapter (ch.tocco.nice2.persist.hibernate.pojo.relation.ToOneRelationQueryAdapter)` is the
+implementation of :abbr:`RelationQuery (ch.tocco.nice2.persist.query.RelationQuery)` used for to-one associations.
 It does not contain any special logic, it simply delegates the calls to the wrapped entity.
 
-:java:ref:`ToOneRelationAdapter<ch.tocco.nice2.persist.hibernate.pojo.relation.ToOneRelationAdapter>` is the implementation
-of :java:ref:`Relation<ch.tocco.nice2.persist.entity.Relation>` for to-one associations. This class implements getting, setting
+:abbr:`ToOneRelationAdapter (ch.tocco.nice2.persist.hibernate.pojo.relation.ToOneRelationAdapter)` is the implementation
+of :abbr:`Relation (ch.tocco.nice2.persist.entity.Relation)` for to-one associations. This class implements getting, setting
 and removing the associated instance.
 
-All access (read or write) goes through the :java:ref:`RelationInterceptor<ch.tocco.nice2.persist.hibernate.RelationInterceptor>`,
+All access (read or write) goes through the :abbr:`RelationInterceptor (ch.tocco.nice2.persist.hibernate.RelationInterceptor)`,
 this allows other modules to add functionality (for example security checks).
 In order to enforce cleaner code, methods that were meant for to-many associations (for example ``RelationInterceptor#addEntity()``)
 are not supported.
 
-The :java:ref:`ToOneRelationAdapter<ch.tocco.nice2.persist.hibernate.pojo.relation.ToOneRelationAdapter>` provides the last
+The :abbr:`ToOneRelationAdapter (ch.tocco.nice2.persist.hibernate.pojo.relation.ToOneRelationAdapter)` provides the last
 interceptor in the chain, which actually accesses the underlying entity.
 
 * Reading the value means simply calling ``Entity#getValue()`` on the source entity. Internally this calls the generated
@@ -114,7 +114,7 @@ interceptor in the chain, which actually accesses the underlying entity.
 To-many relations
 ^^^^^^^^^^^^^^^^^
 
-Collections are loaded lazily by default. We use a special implementation of the :java:extdoc:`PersistentSet<org.hibernate.collection.internal.PersistentSet>`
+Collections are loaded lazily by default. We use a special implementation of the :java-hibernate:`PersistentSet <org/hibernate/collection/internal/PersistentSet>`
 that supports reloading a collection from the database.
 
 See :ref:`collection_reloading` for further information.
@@ -122,19 +122,19 @@ See :ref:`collection_reloading` for further information.
 Every time a to-many relation is resolved, it should be reloaded from the database (because this is the behaviour of the
 old persistence implementation).
 
-:java:ref:`ToManyRelationQueryAdapter<ch.tocco.nice2.persist.hibernate.pojo.relation.ToManyRelationQueryAdapter>` is the
-implementation of :java:ref:`RelationQuery<ch.tocco.nice2.persist.query.RelationQuery>` used for to-many associations.
+:abbr:`ToManyRelationQueryAdapter (ch.tocco.nice2.persist.hibernate.pojo.relation.ToManyRelationQueryAdapter)` is the
+implementation of :abbr:`RelationQuery (ch.tocco.nice2.persist.query.RelationQuery)` used for to-many associations.
 It mainly delegates to the wrapped collection of entities.
 However hibernate does not support pagination or (dynamic) sorting of associations, therefore these cases have to be
 implemented specifically: If a relations needs to be resolved with a specific ordering or pagination an additional query
 will be executed to get the desired results (the collection won't be touched). The results are returned as an
 unmodifiable collection, because changes to this collection would be ignored (as it is unknown to hibernate).
 
-:java:ref:`ToManyRelationAdapter<ch.tocco.nice2.persist.hibernate.pojo.relation.ToManyRelationAdapter>` is the implementation
-of :java:ref:`Relation<ch.tocco.nice2.persist.entity.Relation>` for to-many associations. This class implements applying
+:abbr:`ToManyRelationAdapter (ch.tocco.nice2.persist.hibernate.pojo.relation.ToManyRelationAdapter)` is the implementation
+of :abbr:`Relation (ch.tocco.nice2.persist.entity.Relation)` for to-many associations. This class implements applying
 modifications to the underlying collection.
 
-Like its 'to-one' counterpart it implements the final :java:ref:`RelationInterceptor<ch.tocco.nice2.persist.hibernate.RelationInterceptor>`
+Like its 'to-one' counterpart it implements the final :abbr:`RelationInterceptor (ch.tocco.nice2.persist.hibernate.RelationInterceptor)`
 that actually accesses the underlying collection and also enforces the usage of the correct methods.
 
 If an operation (``addEntity`` or ``removeEntity``) causes a change:
@@ -196,15 +196,15 @@ The states are checked in the following order (important):
 
     * If an entity has a primary key which is auto-generated by the database and this key is null, the state of the
       entity must be conception. For primary keys which are generated by the user (for example strings) this does not work,
-      instead it is checked whether an :java:extdoc:`EntityEntry<org.hibernate.engine.spi.EntityEntry>` for this entity
+      instead it is checked whether an :java-hibernate:`EntityEntry <org/hibernate/engine/spi/EntityEntry>` for this entity
       exists.
-    * Additionally if an entity has its primary key already set and its :java:extdoc:`EntityEntry<org.hibernate.engine.spi.EntityEntry>`
+    * Additionally if an entity has its primary key already set and its :java-hibernate:`EntityEntry <org/hibernate/engine/spi/EntityEntry>`
       status is ``SAVING`` the entity is also in conception state. This can happen when ``Entity#getState()`` is called from
       inside a validator (see ``ValidationInterceptor#onSave()``).
 
 * ``INVALID``
 
-    * If there is no :java:extdoc:`EntityEntry<org.hibernate.engine.spi.EntityEntry>` for an entity and it is not in
+    * If there is no :java-hibernate:`EntityEntry <org/hibernate/engine/spi/EntityEntry>` for an entity and it is not in
       conception state or deleted, it must be invalid.
 
 * ``DIRTY``
@@ -218,21 +218,21 @@ The states are checked in the following order (important):
 Dirty checking
 --------------
 
-The :java:ref:`Entity<ch.tocco.nice2.persist.entity.Entity>` interface differentiates between ``touched`` and ``changed``
+The :abbr:`Entity (ch.tocco.nice2.persist.entity.Entity)` interface differentiates between ``touched`` and ``changed``
 properties. A field is touched when ``setValue()`` has been called at least once for that field, even if the value is still the same.
 As this distinction rarely makes sense, we no longer support it - only ``changed`` fields are returned from the
 dirty checking methods (for example ``Entity#getChangedFields()`` or ``Entity#getTouchedFields()``).
 
-The dirty fields are managed by the abstract base class :java:ref:`AbstractDirtyCheckingEntity<ch.tocco.nice2.persist.hibernate.pojo.AbstractDirtyCheckingEntity>`
+The dirty fields are managed by the abstract base class :abbr:`AbstractDirtyCheckingEntity (ch.tocco.nice2.persist.hibernate.pojo.AbstractDirtyCheckingEntity)`
 in the ``changedFields`` property.
-All calls to the setter methods are intercepted using a custom :java:ref:`PropertyAccessorService<ch.tocco.nice2.persist.hibernate.pojo.PropertyAccessorService>`.
+All calls to the setter methods are intercepted using a custom :abbr:`PropertyAccessorService (ch.tocco.nice2.persist.hibernate.pojo.PropertyAccessorService)`.
 If the value to be set is different from the `Old value`_, the field is marked as changed.
 
 To check for modified collections (to-many relations) we can simply use the ``isDirty()`` method of the
-:java:extdoc:`PersistentCollection<org.hibernate.collection.spi.PersistentCollection>`.
+:java-hibernate:`PersistentCollection <org/hibernate/collection/spi/PersistentCollection>`.
 
 The list of changed fields needs to be reset when the changes are flushed to the database. This is done by the
-:java:ref:`ValidationInterceptor<ch.tocco.nice2.persist.hibernate.validation.ValidationInterceptor>` after the entity
+:abbr:`ValidationInterceptor (ch.tocco.nice2.persist.hibernate.validation.ValidationInterceptor)` after the entity
 validation has been completed.
 
 .. note::
@@ -247,34 +247,34 @@ validation has been completed.
 Old value
 ---------
 
-The :java:ref:`Entity<ch.tocco.nice2.persist.entity.Entity>` interface allows to query for the old value. This is the value
+The :abbr:`Entity (ch.tocco.nice2.persist.entity.Entity)` interface allows to query for the old value. This is the value
 of a certain property when it was loaded from the database at the beginning of the transaction, ignoring all
 uncommitted changes.
 
-This is achieved by checking the 'loaded state' of the :java:extdoc:`EntityEntry<org.hibernate.engine.spi.EntityEntry>`,
-which can be retrieved from the :java:extdoc:`PersistenceContext<org.hibernate.engine.spi.PersistenceContext>`.
+This is achieved by checking the 'loaded state' of the :java-hibernate:`EntityEntry <org/hibernate/engine/spi/EntityEntry>`,
+which can be retrieved from the :java-hibernate:`PersistenceContext <org/hibernate/engine/spi/PersistenceContext>`.
 This is where hibernate stores the state of the entity when it is loaded and this state is also used for hibernate's
 default dirty checking mechanism.
 
 EntityInterceptor
 -----------------
 
-The :java:ref:`EntityInterceptor<ch.tocco.nice2.persist.hibernate.EntityInterceptor>` interface allows
+The :abbr:`EntityInterceptor (ch.tocco.nice2.persist.hibernate.EntityInterceptor)` interface allows
 customizing the core entity functionality. The following functions can be intercepted:
 
     * Reading and writing fields
     * Deleting entities
     * Modifying relations
 
-An entity interceptor instance is injected into every entity by the :java:ref:`EntityFactoryImpl<ch.tocco.nice2.persist.hibernate.pojo.EntityFactoryImpl>`.
-The instance is created by the :java:ref:`EntityInterceptorFactoryImpl<ch.tocco.nice2.persist.hibernate.interceptor.EntityInterceptorFactoryImpl>`
+An entity interceptor instance is injected into every entity by the :abbr:`EntityFactoryImpl (ch.tocco.nice2.persist.hibernate.pojo.EntityFactoryImpl)`.
+The instance is created by the :abbr:`EntityInterceptorFactoryImpl (ch.tocco.nice2.persist.hibernate.interceptor.EntityInterceptorFactoryImpl)`
 which combines all interceptor contributions into an interceptor chain.
 The inner most interceptor (which actually accesses the entity fields and so on) is provided by the entity itself
 (``AbstractHibernateEntity#getInnerInterceptor()``).
 
 .. note::
 
-    The inner interceptor is wrapped in a :java:ref:`LazyInterceptor<ch.tocco.nice2.persist.hibernate.interceptor.EntityInterceptorFactoryImpl.LazyInterceptor>`
+    The inner interceptor is wrapped in a :abbr:`LazyInterceptor (ch.tocco.nice2.persist.hibernate.interceptor.EntityInterceptorFactoryImpl.LazyInterceptor)`
     to avoid recursive proxy initialization (``Entity#getValue()`` -> ``proxy initialization`` ->
     ``EntityFactory#createInstance()`` -> ``Entity#getInnerInterceptor()`` -> ``proxy initialization`` ...).
 
@@ -285,10 +285,10 @@ Accessing values
 The method ``EntityInterceptor#accessField()`` can be used to intercept read or write access to a field.
 It is always called when a value is accessed by the entity (typically when ``Entity#get/setValue()`` is called).
 
-The default inner interceptor simply resolves the field name using the :java:ref:`FieldResolver<ch.tocco.nice2.persist.hibernate.interceptor.FieldResolver>`.
+The default inner interceptor simply resolves the field name using the :abbr:`FieldResolver (ch.tocco.nice2.persist.hibernate.interceptor.FieldResolver)`.
 If write access is requested it additionally checks if the field is not a primary key or other generated field.
 
-The :java:ref:`SecurityEntityInterceptorContribution<ch.tocco.nice2.persist.security.hibernate.SecurityEntityInterceptorContribution>`
+The :abbr:`SecurityEntityInterceptorContribution (ch.tocco.nice2.persist.security.hibernate.SecurityEntityInterceptorContribution)`
 uses this method to check the read or write permission of the given field. If the given field is a localized field, the base field (``label``
 instead of ``label_de``) is used to check permissions.
 
@@ -297,32 +297,32 @@ Deleting entities
 
 ``EntityInterceptor#deleteEntity()`` is called when an entity is deleted (``Entity#delete()``).
 The inner interceptor fires an ``EntityFacadeListener#entityDeleting()`` event and (unless the entity is unsaved)
-schedules the entity for deletion with the :java:ref:`EntityTransactionContext<ch.tocco.nice2.persist.hibernate.cascade.EntityTransactionContext>`.
+schedules the entity for deletion with the :abbr:`EntityTransactionContext (ch.tocco.nice2.persist.hibernate.cascade.EntityTransactionContext)`.
 
-In addition the :java:ref:`SecurityEntityInterceptorContribution<ch.tocco.nice2.persist.security.hibernate.SecurityEntityInterceptorContribution>`
+In addition the :abbr:`SecurityEntityInterceptorContribution (ch.tocco.nice2.persist.security.hibernate.SecurityEntityInterceptorContribution)`
 checks if the ``delete`` permission is granted for the current user.
 
 Modifying relations
 ^^^^^^^^^^^^^^^^^^^
 
-A :java:ref:`RelationInterceptor<ch.tocco.nice2.persist.hibernate.RelationInterceptor>` can be obtained from
+A :abbr:`RelationInterceptor (ch.tocco.nice2.persist.hibernate.RelationInterceptor)` can be obtained from
 the entity interceptor using ``createRelationInterceptor()``. The relation interceptor can be used to intercept
-:java:ref:`Relation<ch.tocco.nice2.persist.entity.Relation>` modifications.
+:abbr:`Relation (ch.tocco.nice2.persist.entity.Relation)` modifications.
 
-The inner interceptors are provided by the :java:ref:`AbstractRelationAdapter<ch.tocco.nice2.persist.hibernate.pojo.relation.AbstractRelationAdapter>`
+The inner interceptors are provided by the :abbr:`AbstractRelationAdapter (ch.tocco.nice2.persist.hibernate.pojo.relation.AbstractRelationAdapter)`
 implementations. These update the relation value or collection and fire an ``EntityFacadeListener#entityRelationChanging()`` event.
 
-In addition the :java:ref:`SecurityEntityInterceptorContribution<ch.tocco.nice2.persist.security.hibernate.SecurityEntityInterceptorContribution>`
+In addition the :abbr:`SecurityEntityInterceptorContribution (ch.tocco.nice2.persist.security.hibernate.SecurityEntityInterceptorContribution)`
 checks if the current user is allowed to modify a relation.
 
-The :java:ref:`BusinessUnitEntityInterceptor<ch.tocco.nice2.businessunit.impl.intercept.BusinessUnitEntityInterceptorContribution.BusinessUnitEntityInterceptor>`
+The :abbr:`BusinessUnitEntityInterceptor (ch.tocco.nice2.businessunit.impl.intercept.BusinessUnitEntityInterceptorContribution.BusinessUnitEntityInterceptor)`
 checks if the business unit of an entity may be manually changed by the user (only business unit types ``MANUAL_SET``
 and ``NONE`` may be changed by the user).
 
 FieldResolver
 ^^^^^^^^^^^^^
 
-The :java:ref:`FieldResolverImpl<ch.tocco.nice2.persist.hibernate.interceptor.FieldResolverImpl>` resolves a property name
+The :abbr:`FieldResolverImpl (ch.tocco.nice2.persist.hibernate.interceptor.FieldResolverImpl)` resolves a property name
 to the name of the corresponding entity field.
 Usually the property name is equal to the entity field name, however there are two exceptions:
 

--- a/framework/architecture/hibernate/collections.rst
+++ b/framework/architecture/hibernate/collections.rst
@@ -3,7 +3,7 @@
 Collections
 ===========
 
-To many relations are mapped by collections. We use a :java:extdoc:`LinkedHashSet<java.util.LinkedHashSet>` because
+To many relations are mapped by collections. We use a :java:`LinkedHashSet <java/util/LinkedHashSet>` because
 we want a unique collection that does preserve the order (to be able to define a default sorting).
 
 In order to provide the same behaviour for collections as in the old API, some extensions were necessary.
@@ -17,14 +17,14 @@ current business unit or security.
 
 `Hibernate Filters <https://docs.jboss.org/hibernate/orm/5.2/userguide/html_single/Hibernate_User_Guide.html#mapping-column-filter>`_
 are unfortunately not flexible enough for our needs.
-Therefore a custom :java:extdoc:`InitializeCollectionEventListener<org.hibernate.event.spi.InitializeCollectionEventListener>` was
-implemented: :java:ref:`ExtendedInitializeCollectionEventListener<ch.tocco.nice2.persist.hibernate.interceptor.ExtendedInitializeCollectionEventListener>`.
+Therefore a custom :java-hibernate:`InitializeCollectionEventListener <org/hibernate/event/spi/InitializeCollectionEventListener>` was
+implemented: :abbr:`ExtendedInitializeCollectionEventListener (ch.tocco.nice2.persist.hibernate.interceptor.ExtendedInitializeCollectionEventListener)`.
 
 Unfortunately it is not possible to simply provide a list of entities to initialize a collection, because they
-are initialized directly from a :java:extdoc:`ResultSet<java.sql.ResultSet>` (see ``PersistentCollection#readFrom()``).
-This is done when a :java:extdoc:`Loader<org.hibernate.loader.Loader>` contains a collection persister.
+are initialized directly from a :java:`ResultSet <java/sql/ResultSet>` (see ``PersistentCollection#readFrom()``).
+This is done when a :java-hibernate:`Loader <org/hibernate/loader/Loader>` contains a collection persister.
 We did not find an appropriate way to implement such a loader to load collections with dynamically generated conditions,
-therefore a workaround was necessary in :java:ref:`ExtendedInitializeCollectionEventListener<ch.tocco.nice2.persist.hibernate.interceptor.ExtendedInitializeCollectionEventListener>`:
+therefore a workaround was necessary in :abbr:`ExtendedInitializeCollectionEventListener (ch.tocco.nice2.persist.hibernate.interceptor.ExtendedInitializeCollectionEventListener)`:
 
 .. code-block:: java
 
@@ -46,9 +46,9 @@ therefore a workaround was necessary in :java:ref:`ExtendedInitializeCollectionE
         .getCollectionLoadContext(fake)
         .endLoadingCollections(loadedPersister);
 
-First a fake :java:extdoc:`ResultSet<java.sql.ResultSet>` is created using the :java:extdoc:`ProxyFactory<javassist.util.proxy.ProxyFactory>`
+First a fake :java:`ResultSet <java/sql/ResultSet>` is created using the :java-javassist:`ProxyFactory <javassist/util/proxy/ProxyFactory>`
 (required as key) and then the persistence context is informed that a collection is about to be loaded.
-Instead of using a :java:extdoc:`ResultSet<java.sql.ResultSet>` to initialize the collection, the collection elements
+Instead of using a :java:`ResultSet <java/sql/ResultSet>` to initialize the collection, the collection elements
 are added by reflection. After all elements are set, the persistence context is informed that collection loading is
 completed.
 
@@ -63,41 +63,41 @@ completed.
 CollectionInitializer
 ---------------------
 
-The loading of the collection elements is delegated to an instance of :java:ref:`CollectionInitializer<ch.tocco.nice2.persist.hibernate.interceptor.CollectionInitializer>`.
+The loading of the collection elements is delegated to an instance of :abbr:`CollectionInitializer (ch.tocco.nice2.persist.hibernate.interceptor.CollectionInitializer)`.
 
-The :java:ref:`ExtendedInitializeCollectionEventListener<ch.tocco.nice2.persist.hibernate.interceptor.ExtendedInitializeCollectionEventListener>`
-fetches the matching :java:ref:`CollectionInitializer<ch.tocco.nice2.persist.hibernate.interceptor.CollectionInitializer>` from the
-:java:ref:`CollectionInitializationService<ch.tocco.nice2.persist.hibernate.interceptor.CollectionInitializationService>`.
+The :abbr:`ExtendedInitializeCollectionEventListener (ch.tocco.nice2.persist.hibernate.interceptor.ExtendedInitializeCollectionEventListener)`
+fetches the matching :abbr:`CollectionInitializer (ch.tocco.nice2.persist.hibernate.interceptor.CollectionInitializer)` from the
+:abbr:`CollectionInitializationService (ch.tocco.nice2.persist.hibernate.interceptor.CollectionInitializationService)`.
 
-A :java:ref:`CollectionInitializer<ch.tocco.nice2.persist.hibernate.interceptor.CollectionInitializer>` implementation
+A :abbr:`CollectionInitializer (ch.tocco.nice2.persist.hibernate.interceptor.CollectionInitializer)` implementation
 can be enabled for a specific association using the ``supports()`` method. The ``priority()`` method should be overridden
 by more specific implementations so that they are selected before the more generic implementations.
 
-The :java:ref:`CollectionInitializer<ch.tocco.nice2.persist.hibernate.interceptor.CollectionInitializer>` provides two main
+The :abbr:`CollectionInitializer (ch.tocco.nice2.persist.hibernate.interceptor.CollectionInitializer)` provides two main
 methods:
 
     * ``getCollectionElements()`` fetches all elements of a given association, including support for pagination and ordering
     * ``countCollectionElements()`` counts the collection elements without loading them all
 
-The default :java:ref:`CollectionInitializer<ch.tocco.nice2.persist.hibernate.interceptor.CollectionInitializer>` is the
-:java:ref:`DefaultCollectionInitializer<ch.tocco.nice2.persist.hibernate.interceptor.DefaultCollectionInitializer>`.
+The default :abbr:`CollectionInitializer (ch.tocco.nice2.persist.hibernate.interceptor.CollectionInitializer)` is the
+:abbr:`DefaultCollectionInitializer (ch.tocco.nice2.persist.hibernate.interceptor.DefaultCollectionInitializer)`.
 
-Most of the functionality is implemented in :java:ref:`AbstractCollectionInitializer<ch.tocco.nice2.persist.hibernate.interceptor.AbstractCollectionInitializer>`,
+Most of the functionality is implemented in :abbr:`AbstractCollectionInitializer (ch.tocco.nice2.persist.hibernate.interceptor.AbstractCollectionInitializer)`,
 which is the base class of all implementations.
-It uses the :java:ref:`CriteriaQueryBuilder<ch.tocco.nice2.persist.hibernate.query.CriteriaQueryBuilder>` to execute
+It uses the :abbr:`CriteriaQueryBuilder (ch.tocco.nice2.persist.hibernate.query.CriteriaQueryBuilder)` to execute
 a query for the reverse relation.
-Since the query is dynamically modified by all :java:ref:`QueryBuilderInterceptor<ch.tocco.nice2.persist.hibernate.query.QueryBuilderInterceptor>`,
+Since the query is dynamically modified by all :abbr:`QueryBuilderInterceptor (ch.tocco.nice2.persist.hibernate.query.QueryBuilderInterceptor)`,
 security and business unit conditions are added as well (which would not be the case when using Hibernate collections directly).
 
 See :ref:`query_builder` for more information about this topic.
 
-Currently there are a couple of special implementations of :java:ref:`CollectionInitializer<ch.tocco.nice2.persist.hibernate.interceptor.CollectionInitializer>`:
+Currently there are a couple of special implementations of :abbr:`CollectionInitializer (ch.tocco.nice2.persist.hibernate.interceptor.CollectionInitializer)`:
 
-    * :java:ref:`AbstractEntityDocsCollectionInitializer<ch.tocco.nice2.dms.impl.entitydocs.interceptor.AbstractEntityDocsCollectionInitializer>`
+    * :abbr:`AbstractEntityDocsCollectionInitializer (ch.tocco.nice2.dms.impl.entitydocs.interceptor.AbstractEntityDocsCollectionInitializer)`
       is the base class for several entity-docs related collection initializers. There are no ACL rules for entity-docs, therefore a special
       implementation is required for loading entity-docs collections.
 
-    * :java:ref:`NodeChildrenCollectionInitializer<ch.tocco.nice2.dms.impl.security.NodeChildrenCollectionInitializer>` is a
+    * :abbr:`NodeChildrenCollectionInitializer (ch.tocco.nice2.dms.impl.security.NodeChildrenCollectionInitializer)` is a
       collection initializer that improves the performance of loading child nodes of ``Folder`` entities.
 
 .. _collection_reloading:
@@ -109,10 +109,10 @@ Per default a collection cannot be reloaded from the database once it has been i
 However, when a relation is resolved the collection should always be reloaded from the database because
 a relation may be resolved multiple times within the same transaction with different privileges.
 
-To support this, we use a custom persistent collection type, the :java:ref:`ReloadablePersistentCollectionType<ch.tocco.nice2.persist.hibernate.usertype.ReloadablePersistentCollectionType>`.
+To support this, we use a custom persistent collection type, the :abbr:`ReloadablePersistentCollectionType (ch.tocco.nice2.persist.hibernate.usertype.ReloadablePersistentCollectionType)`.
 This type is configured for all collections (see :doc:`entity-class-generation`).
 
-The concrete collection implementation is the :java:ref:`ReloadablePersistentSet<ch.tocco.nice2.persist.hibernate.usertype.ReloadablePersistentSet>`,
+The concrete collection implementation is the :abbr:`ReloadablePersistentSet (ch.tocco.nice2.persist.hibernate.usertype.ReloadablePersistentSet)`,
 which has the following features:
 
 Reloading
@@ -135,7 +135,7 @@ The code snippets which unload and then load the collection have been taken from
 of the Hibernate source code.
 
 * The initialized flag of the collection needs to be reset to false (using reflection)
-* The collection needs to be evicted from the session (based on code from :java:extdoc:`EvictVisitor<org.hibernate.event.internal.EvictVisitor>`)
+* The collection needs to be evicted from the session (based on code from :java-hibernate:`EvictVisitor <org/hibernate/event/internal/EvictVisitor>`)
 * The collection needs to be loaded from the database and attached to the session again
 * Uncommitted changes must be applied again
 

--- a/framework/architecture/hibernate/entity-class-generation.rst
+++ b/framework/architecture/hibernate/entity-class-generation.rst
@@ -4,15 +4,15 @@ Entity class generation
 Introduction
 ------------
 All entities in nice2 are currently defined by \*.xml files, which are then parsed
-into an :java:ref:`EntityModel<ch.tocco.nice2.persist.model.EntityModel>` instance.
+into an :abbr:`EntityModel (ch.tocco.nice2.persist.model.EntityModel)` instance.
 
-There are two different :java:extdoc:`EntityMode<org.hibernate.EntityMode>` in hibernate:
+There are two different :java-hibernate:`EntityMode <org/hibernate/EntityMode>` in hibernate:
 
 - POJO (a different class per entity)
 - MAP (entities based on maps)
 
 As the two modes cannot be mixed and we would like to be able to use typed entities (instead of just the
-:java:ref:`Entity<ch.tocco.nice2.persist.entity.Entity>` interface) in the future we need to dynamically generate classes for the entity models.
+:abbr:`Entity (ch.tocco.nice2.persist.entity.Entity)` interface) in the future we need to dynamically generate classes for the entity models.
 
 The `javassist <https://www.javassist.org/>`_ library is used to generate the classes. The same
 library is used by  Hibernate 5.2.x itself to generate proxy classes. `Bytebuddy <https://bytebuddy.net/>`_ would
@@ -20,11 +20,11 @@ be a more modern alternative, but the newest version is much `slower <https://st
 
 Class generation
 ----------------
-The classes are generated during startup by the :java:ref:`JavassistEntityPojoFactory<ch.tocco.nice2.persist.hibernate.pojo.ch.tocco.nice2.persist.hibernate.pojo.JavassistEntityPojoFactory>`.
+The classes are generated during startup by the :abbr:`JavassistEntityPojoFactory (ch.tocco.nice2.persist.hibernate.pojo.ch.tocco.nice2.persist.hibernate.pojo.JavassistEntityPojoFactory)`.
 At first an 'empty' class is generated for each entity model, so that they can already be referenced by other classes.
 
-All generated entity classes inherit from the same base class (:java:ref:`AbstractPojoEntity<ch.tocco.nice2.persist.hibernate.pojo.AbstractPojoEntity>`),
-which implements all of the logic required by the :java:ref:`Entity<ch.tocco.nice2.persist.entity.Entity>`
+All generated entity classes inherit from the same base class (:abbr:`AbstractPojoEntity (ch.tocco.nice2.persist.hibernate.pojo.AbstractPojoEntity)`),
+which implements all of the logic required by the :abbr:`Entity (ch.tocco.nice2.persist.entity.Entity)`
 interface.
 
 The generated classes contain the following:
@@ -44,50 +44,50 @@ Transient entities
 ^^^^^^^^^^^^^^^^^^
 
 There are so called 'session-only' entities in nice2 which are not mapped to the database (used only for data binding and the like).
-A different base class (:java:ref:`AbstractSessionOnlyEntity<ch.tocco.nice2.persist.hibernate.pojo.AbstractSessionOnlyEntity>`)
+A different base class (:abbr:`AbstractSessionOnlyEntity (ch.tocco.nice2.persist.hibernate.pojo.AbstractSessionOnlyEntity)`)
 is used for those entities and no JPA annotations are added.
-They are basically normal java beans that implement the :java:ref:`Entity<ch.tocco.nice2.persist.entity.Entity>` interface.
+They are basically normal java beans that implement the :abbr:`Entity (ch.tocco.nice2.persist.entity.Entity)` interface.
 If such an entity is used in an association with a normal entity, no JPA annotations may be used on both sides, only
 a normal field (or collection) is created.
 
 Entities
 ^^^^^^^^
 
-Apart from the usual :java:extdoc:`Entity<javax.persistence.Entity>` annotation, the database table name is
-explicitly defined with the :java:extdoc:`Table<javax.persistence.Table>` annotation (we need to use the same
+Apart from the usual :java-javax:`Entity <javax/persistence/Entity>` annotation, the database table name is
+explicitly defined with the :java-javax:`Table <javax/persistence/Table>` annotation (we need to use the same
 naming strategy to be compatible with existing databases).
-A custom :java:extdoc:`EntityPersister<org.hibernate.persister.entity.EntityPersister>` is defined as well (see
+A custom :java-hibernate:`EntityPersister <org/hibernate/persister/entity/EntityPersister>` is defined as well (see
 :ref:`persister` for details).
 
 Fields
 ^^^^^^
 
-All fields are annotated with the :java:extdoc:`Column<javax.persistence.Column>` annotation to define the
+All fields are annotated with the :java-javax:`Column <javax/persistence/Column>` annotation to define the
 column name of this field (we need to use the same naming strategy to be compatible with existing databases).
 
 **Primary Key**
 
-The primary key must be annotated with :java:extdoc:`Id<javax.persistence.Id>`. If the key value is generated
-by the database the annotation :java:extdoc:`GeneratedValue<javax.persistence.GeneratedValue>` is required as well.
+The primary key must be annotated with :java-javax:`Id <javax/persistence/Id>`. If the key value is generated
+by the database the annotation :java-javax:`GeneratedValue <javax/persistence/GeneratedValue>` is required as well.
 For autoincrement columns, the correct strategy is ``IDENTITY``.
 
 **Version**
 
-Fields of type version are annotated with :java:extdoc:`Version<javax.persistence.Version>`, which enables optimistic
+Fields of type version are annotated with :java-javax:`Version <javax/persistence/Version>`, which enables optimistic
 locking for this entity.
 
 **Text fields**
 
-The ``text`` datatype is a :java:extdoc:`String<java.lang.String>` that should be saved into a column with datatype
-``text``. To achieve this we add the :java:extdoc:`Lob<javax.persistence.Lob>` annotation to the property.
+The ``text`` datatype is a :java:`String <java/lang/String>` that should be saved into a column with datatype
+``text``. To achieve this we add the :java-javax:`Lob <javax/persistence/Lob>` annotation to the property.
 
 .. note::
-    In Hibernate 5.2.10 a String property annotated with :java:extdoc:`Lob<javax.persistence.Lob>` was automatically
+    In Hibernate 5.2.10 a String property annotated with :java-javax:`Lob <javax/persistence/Lob>` was automatically
     mapped to a ``text`` column in PostgreSQL.
 
     However the behaviour changed in version 5.2.11 (see the `migration guide <https://github.com/hibernate/hibernate-orm/wiki/Migration-Guide---5.2>`_).
     To be compatible with existing databases, we need the behaviour of 5.2.10. In order to accomplish this, a custom
-    :java:extdoc:`ClobTypeDescriptor<org.hibernate.type.descriptor.sql.ClobTypeDescriptor>` is registered in the :java:ref:`ToccoPostgreSQLDialect<ch.tocco.nice2.persist.hibernate.dialect.ToccoPostgreSQLDialect>`
+    :java-hibernate:`ClobTypeDescriptor <org/hibernate/type/descriptor/sql/ClobTypeDescriptor>` is registered in the :abbr:`ToccoPostgreSQLDialect (ch.tocco.nice2.persist.hibernate.dialect.ToccoPostgreSQLDialect)`
     which restores the behaviour of 5.2.10.
 
 **Counter fields**
@@ -95,8 +95,8 @@ The ``text`` datatype is a :java:extdoc:`String<java.lang.String>` that should b
 The ``counter`` datatype is a numeric type whose value is automatically generated. The value is incremented for every new entity instance.
 The counter values are managed in the ``nice_counter`` table.
 
-Counter fields are annotated with :java:ref:`Counter<ch.tocco.nice2.persist.hibernate.pojo.generator.Counter>`, which configures
-the :java:ref:`CounterGeneration<ch.tocco.nice2.persist.hibernate.pojo.generator.CounterGeneration>` value generator. This
+Counter fields are annotated with :abbr:`Counter (ch.tocco.nice2.persist.hibernate.pojo.generator.Counter)`, which configures
+the :abbr:`CounterGeneration (ch.tocco.nice2.persist.hibernate.pojo.generator.CounterGeneration)` value generator. This
 generator is only applied whenever a new entity is inserted (not when an entity is updated).
 
 If the value of a counter field is manually set in the transaction it will not be overwritten.
@@ -113,12 +113,12 @@ the same database transaction.
 
 **Custom user types**
 
-Custom user types are mapped using the :java:extdoc:`Type<org.hibernate.annotations.Type>` annotation.
+Custom user types are mapped using the :java-hibernate:`Type <org/hibernate/annotations/Type>` annotation.
 See the chapter :ref:`user-types` for more details.
 
 **Other fields**
 
-The ``nullable``, ``unique`` and if applicable ``precision`` and ``scale`` properties are set on the :java:extdoc:`Column<javax.persistence.Column>` annotation.
+The ``nullable``, ``unique`` and if applicable ``precision`` and ``scale`` properties are set on the :java-javax:`Column <javax/persistence/Column>` annotation.
 These properties are only used for schema generation in test cases (databases are setup by liquibase), not for
 validation!
 The type ``decimal`` (without precision and scale) is handled specially, because Hibernate would use a default
@@ -130,8 +130,8 @@ Generated fields
 ^^^^^^^^^^^^^^^^
 
 It is possible to define custom data types whose values are automatically set when an entity is saved or updated.
-These fields are annotated either with the :java:ref:`AlwaysGeneratedValue<ch.tocco.nice2.persist.hibernate.pojo.generator.AlwaysGeneratedValue>`
-for fields which should be updated on create and update or the :java:ref:`InsertGeneratedValue<ch.tocco.nice2.persist.hibernate.pojo.generator.InsertGeneratedValue>`
+These fields are annotated either with the :abbr:`AlwaysGeneratedValue (ch.tocco.nice2.persist.hibernate.pojo.generator.AlwaysGeneratedValue)`
+for fields which should be updated on create and update or the :abbr:`InsertGeneratedValue (ch.tocco.nice2.persist.hibernate.pojo.generator.InsertGeneratedValue)`
 for fields which should only be updated when the entity is created.
 
 See :ref:`generated-values`.
@@ -141,41 +141,41 @@ Associations
 
 Associations (relations) are annotated with one of the following JPA annotations (depending on the type):
 
-- :java:extdoc:`OneToMany<javax.persistence.OneToMany>`
-- :java:extdoc:`ManyToOne<javax.persistence.ManyToOne>`
-- :java:extdoc:`ManyToMany<javax.persistence.ManyToMany>`
+- :java-javax:`OneToMany <javax/persistence/OneToMany>`
+- :java-javax:`ManyToOne <javax/persistence/ManyToOne>`
+- :java-javax:`ManyToMany <javax/persistence/ManyToMany>`
 
 So far all associations are bi-directional (even if this does not always make sense).
 In a ManyToOne/OneToMany association, the ManyToOne side is always the owning side. In a ManyToMany association,
-the owning side needs to be explicitly specified (with the :java:extdoc:`JoinTable<javax.persistence.JoinTable>`
+the owning side needs to be explicitly specified (with the :java-javax:`JoinTable <javax/persistence/JoinTable>`
 annotation).
 The owning side is responsible for persisting the relationship - if a change is only done on the inverse side of
 an association, it will not be persisted! For example in a ManyToMany association, entities must always be added
 and removed from the owning side, otherwise the mapping table won't be updated.
 
-For collections a :java:extdoc:`LinkedHashSet<java.util.LinkedHashSet>` is used, because we want :java:extdoc:`LinkedHashSet<java.util.Set>` semantics
+For collections a :java:`LinkedHashSet <java/util/LinkedHashSet>` is used, because we want :java:`LinkedHashSet <java/util/Set>` semantics
 (no duplicates), but need to iterate over the elements in the same order as they were inserted (to support sorting by the database).
 
-All associations (including ManyToOne) are configured to be loaded lazily by specifying the :java:extdoc:`FetchType<javax.persistence.FetchType>`
+All associations (including ManyToOne) are configured to be loaded lazily by specifying the :java-javax:`FetchType <javax/persistence/FetchType>`
 on the annotation. Per default only to many associations are loaded lazily, that's why we need to explicitly configure
 it for to one associations.
 
 When a collection has been initialized it cannot be reloaded from the database (unless the entire object is reloaded).
-However when a  :java:ref:`Relation<ch.tocco.nice2.persist.entity.Relation>` is resolved, the data should always be
+However when a  :abbr:`Relation (ch.tocco.nice2.persist.entity.Relation)` is resolved, the data should always be
 loaded from the database (because this was the behaviour of the old persistence implementation).
-To support this behaviour we use a custom collection type (:java:extdoc:`CollectionType<org.hibernate.annotations.CollectionType>`).
+To support this behaviour we use a custom collection type (:java-hibernate:`CollectionType <org/hibernate/annotations/CollectionType>`).
 
 See :ref:`collections` chapter for more details.
 
-A custom :java:extdoc:`CollectionPersister<org.hibernate.persister.collection.CollectionPersister>` is also configured (see
+A custom :java-hibernate:`CollectionPersister <org/hibernate/persister/collection/CollectionPersister>` is also configured (see
 :ref:`persister` for details).
 
 Class loading
 -------------
 
-The :java:ref:`ClassUtils<ch.tocco.nice2.persist.hibernate.session.ClassUtils>` can be used to load the generated classes
+The :abbr:`ClassUtils (ch.tocco.nice2.persist.hibernate.session.ClassUtils)` can be used to load the generated classes
 by name.
-The classes are retrieved from the hibernate :java:extdoc:`Metamodel<org.hibernate.Metamodel>`. The reason for this is that
+The classes are retrieved from the hibernate :java-hibernate:`Metamodel <org/hibernate/Metamodel>`. The reason for this is that
 those classes are generated during the initialization of Hibernate and getting them from the Metamodel ensures
 that the classes have been properly initialized (in contrast to loading them directly from the class loader).
 

--- a/framework/architecture/hibernate/entity-persister.rst
+++ b/framework/architecture/hibernate/entity-persister.rst
@@ -6,15 +6,15 @@ Custom persisters
 Custom entity persister
 -----------------------
 
-The :java:extdoc:`EntityPersister<org.hibernate.persister.entity.EntityPersister>` interface contains information how to
+The :java-hibernate:`EntityPersister <org/hibernate/persister/entity/EntityPersister>` interface contains information how to
 map an entity to the database table. There is one instance per mapped class.
-We extend Hibernate's default implementations to achieve some custom behaviour (:java:ref:`CustomEntityPersister<ch.tocco.nice2.persist.hibernate.CustomEntityPersister>`).
+We extend Hibernate's default implementations to achieve some custom behaviour (:abbr:`CustomEntityPersister (ch.tocco.nice2.persist.hibernate.CustomEntityPersister)`).
 
 Lazy initialization of UniqueEntityLoader cache
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Hibernate initializes an instance of :java:extdoc:`UniqueEntityLoader<org.hibernate.loader.entity.UniqueEntityLoader>`
-per :java:extdoc:`LockMode<org.hibernate.LockMode>`. This can use quite a lot of memory if there are a lot of entity classes.
+Hibernate initializes an instance of :java-hibernate:`UniqueEntityLoader <org/hibernate/loader/entity/UniqueEntityLoader>`
+per :java-hibernate:`LockMode <org/hibernate/LockMode>`. This can use quite a lot of memory if there are a lot of entity classes.
 Since we almost exclusively use the standard lock mode a lot of these loaders will never be used. In addition, these loaders
 are primarily used to load an entity by primary key, which we rarely use because we almost always use the query builder
 (to make sure business unit and security conditions are added).
@@ -40,7 +40,7 @@ For each 'one to many' association (whose inverse side is nullable) the followin
 
 .. note::
     It is important that these queries are executed directly before the delete statements are executed
-    (instead of for example doing it in :java:extdoc:`DeleteEventListener<org.hibernate.event.spi.DeleteEventListener>`.)
+    (instead of for example doing it in :java-hibernate:`DeleteEventListener <org/hibernate/event/spi/DeleteEventListener>`.)
     Otherwise the ``NULL`` values might be overridden by an update statement.
 
 .. _persister-entity-instantiation:
@@ -50,8 +50,8 @@ Entity instantiation
 
 By default Hibernate instantiates entity classes by invoking their default constructor.
 Entity instantiation is intercepted by overriding ``EntityPersister#instantiate()``; the instantiation itself is then
-delegated to the :java:ref:`EntityFactory<ch.tocco.nice2.persist.hibernate.pojo.EntityFactory>`.
-The :java:ref:`EntityFactory<ch.tocco.nice2.persist.hibernate.pojo.EntityFactory>` injects services into
+delegated to the :abbr:`EntityFactory (ch.tocco.nice2.persist.hibernate.pojo.EntityFactory)`.
+The :abbr:`EntityFactory (ch.tocco.nice2.persist.hibernate.pojo.EntityFactory)` injects services into
 the created entities, tracks new entities and invokes listeners.
 
 Before the entity factory is called it is verified whether the entity to be created belongs to the current
@@ -60,7 +60,7 @@ Session/Context. This is important as otherwise the wrong Session/Context would 
 Custom collection persister
 ---------------------------
 
-There is an instance of a :java:extdoc:`CollectionPersister<org.hibernate.persister.collection.CollectionPersister>` for
+There is an instance of a :java-hibernate:`CollectionPersister <org/hibernate/persister/collection/CollectionPersister>` for
 every collection. Like with the entity persister, a customized implementation is used.
 
 Filtered collections
@@ -74,5 +74,5 @@ mapping table, which might wrongfully remove filtered data from the database).
 Lazy initialization of CollectionInitializer
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The :java:extdoc:`CollectionInitializer<org.hibernate.loader.collection.CollectionInitializer>` instances are also lazily
+The :java-hibernate:`CollectionInitializer <org/hibernate/loader/collection/CollectionInitializer>` instances are also lazily
 initialized for the same reasons as above (memory usage and startup performance).

--- a/framework/architecture/hibernate/entity-transaction-context.rst
+++ b/framework/architecture/hibernate/entity-transaction-context.rst
@@ -3,7 +3,7 @@
 Transaction context
 ===================
 
-The :java:ref:`EntityTransactionContext<ch.tocco.nice2.persist.hibernate.cascade.EntityTransactionContext>` collects
+The :abbr:`EntityTransactionContext (ch.tocco.nice2.persist.hibernate.cascade.EntityTransactionContext)` collects
 entities that have been created or deleted during the transaction and applies these changes to the session before
 the transaction is committed.
 
@@ -14,8 +14,8 @@ All calls to ``Entity#delete()`` are recorded and then executed before the trans
 will be reordered so that no constraint violations can occur on the database. That means it does not matter in which
 order the entities are deleted by the user.
 
-The service is a singleton and all changes are stored in maps using the current :java:extdoc:`Session<org.hibernate.Session>`
-as key. The values are removed by the :java:ref:`TransactionControl<ch.tocco.nice2.persist.hibernate.TransactionControl>`
+The service is a singleton and all changes are stored in maps using the current :java-hibernate:`Session <org/hibernate/Session>`
+as key. The values are removed by the :abbr:`TransactionControl (ch.tocco.nice2.persist.hibernate.TransactionControl)`
 after each commit or rollback.
 
 Created entities
@@ -25,8 +25,8 @@ In a first step all entities that are created and deleted in the same transactio
 of entities to be inserted. This is necessary sometimes, as all entities are going to be saved automatically
 when they are created within a transaction.
 
-After that all newly created entities are passed to the :java:ref:`EntityInsertActionResolver<ch.tocco.nice2.persist.hibernate.cascade.EntityInsertActionResolver>`
-which creates a list of :java:ref:`EntityInsertAction<ch.tocco.nice2.persist.hibernate.cascade.EntityInsertAction>`.
+After that all newly created entities are passed to the :abbr:`EntityInsertActionResolver (ch.tocco.nice2.persist.hibernate.cascade.EntityInsertActionResolver)`
+which creates a list of :abbr:`EntityInsertAction (ch.tocco.nice2.persist.hibernate.cascade.EntityInsertAction)`.
 The returned list is ordered such that no constraint violations can occur when the insert statements are executed.
 
 All that needs to be done is to make sure that unsaved entities which have non-nullable many-to-one reference
@@ -35,43 +35,43 @@ references) are correctly ordered by hibernate.
 
 .. note::
 
-    Also have a look at the javadoc in :java:ref:`EntityTransactionContextTest<ch.tocco.nice2.persist.hibernate.EntityTransactionContextTest>`
-    and :java:ref:`EntityInsertActionResolver<ch.tocco.nice2.persist.hibernate.cascade.EntityInsertActionResolver>`
+    Also have a look at the javadoc in :abbr:`EntityTransactionContextTest (ch.tocco.nice2.persist.hibernate.EntityTransactionContextTest)`
+    and :abbr:`EntityInsertActionResolver (ch.tocco.nice2.persist.hibernate.cascade.EntityInsertActionResolver)`
     for more implementation details.
 
 Entity factory
 ^^^^^^^^^^^^^^
 
-All :java:ref:`Entity<ch.tocco.nice2.persist.entity.Entity>` instances are instantiated by the :java:ref:`EntityFactoryImpl<ch.tocco.nice2.persist.hibernate.pojo.EntityFactoryImpl>`:
+All :abbr:`Entity (ch.tocco.nice2.persist.entity.Entity)` instances are instantiated by the :abbr:`EntityFactoryImpl (ch.tocco.nice2.persist.hibernate.pojo.EntityFactoryImpl)`:
 
     * All entities created by the user are delegated from ``PersistenceService#create()`` to the entity factory.
     * Entities that are instantiated by Hibernate (for example as a result of a query) are also delegated to
-      the entity factory by the :java:ref:`CustomEntityPersister<ch.tocco.nice2.persist.hibernate.CustomEntityPersister>` (see :ref:`persister-entity-instantiation`).
+      the entity factory by the :abbr:`CustomEntityPersister (ch.tocco.nice2.persist.hibernate.CustomEntityPersister)` (see :ref:`persister-entity-instantiation`).
 
-The first purpose is to inject several necessary services into the :java:ref:`Entity<ch.tocco.nice2.persist.entity.Entity>`
-instances, for example the current :java:ref:`Context<ch.tocco.nice2.persist.Context>` or the :java:ref:`NiceEntityModel<ch.tocco.nice2.model.NiceEntityModel>`.
+The first purpose is to inject several necessary services into the :abbr:`Entity (ch.tocco.nice2.persist.entity.Entity)`
+instances, for example the current :abbr:`Context (ch.tocco.nice2.persist.Context)` or the :abbr:`NiceEntityModel (ch.tocco.nice2.model.NiceEntityModel)`.
 
 In addition the following listeners are invoked when an entity was instantiated:
 
     * ``EntityFacadeListener#entityCreating`` is called for every newly created entity (this is *not* called for entities that are loaded from the database).
-    * :java:ref:`EntityCreationListener<ch.tocco.nice2.persist.hibernate.EntityCreationListener>` are called for every
+    * :abbr:`EntityCreationListener (ch.tocco.nice2.persist.hibernate.EntityCreationListener)` are called for every
       created entity instance (``entityCreated()`` for new entities and ``entityLoaded()`` for existing entities).
 
-Newly created entities are added to :java:ref:`EntityTransactionContext<ch.tocco.nice2.persist.hibernate.cascade.EntityTransactionContext>`
+Newly created entities are added to :abbr:`EntityTransactionContext (ch.tocco.nice2.persist.hibernate.cascade.EntityTransactionContext)`
 so that they will be persisted at the end of the transaction.
 
 .. note::
 
     There is a caveat for entities loaded from the database: It is possible that the entity instantiation is actually
-    the initialization of a :java:extdoc:`HibernateProxy<org.hibernate.proxy.HibernateProxy>`. In this case it is important
+    the initialization of a :java-hibernate:`HibernateProxy <org/hibernate/proxy/HibernateProxy>`. In this case it is important
     to pass the proxy instance to the listeners (instead of the actual entity instance). Otherwise there are multiple
     entity instances representing the same database row, which will lead to unexpected side effects.
 
-:java:ref:`EntityCreationListener<ch.tocco.nice2.persist.hibernate.EntityCreationListener>`
+:abbr:`EntityCreationListener (ch.tocco.nice2.persist.hibernate.EntityCreationListener)`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This listener (comparable to ``EntityFacadeListener#entityCreating``) is meant to be used by framework
-code and will be called before all :java:ref:`EntityFacadeListener<ch.tocco.nice2.persist.entity.events.EntityFacadeListener>`
+code and will be called before all :abbr:`EntityFacadeListener (ch.tocco.nice2.persist.entity.events.EntityFacadeListener)`
 which are supposed to be used by business code.
 
 
@@ -81,7 +81,7 @@ Deleted entities
 Similar considerations need to be made when deleting multiple entities. Entities that are being referenced by other
 deleted entities must be deleted first to avoid constraint violation errors (which is the reverse order of the insert).
 
-The deletion is done by the :java:ref:`EntityDeletionUtils<ch.tocco.nice2.model.util.EntityDeletionUtils>` based on a
+The deletion is done by the :abbr:`EntityDeletionUtils (ch.tocco.nice2.model.util.EntityDeletionUtils)` based on a
 list of entity models.
 
 A dependency map is created based on the existing relations between the entity models (a ``Multimap<NiceEntityModel, NiceEntityModel>``).
@@ -102,7 +102,7 @@ Batch deletion
 Using ``addDeletedEntityBatch()`` a list of entities can be scheduled for deletion with a single statement. This is more
 efficient than executing a single query for each entity.
 
-The entities are deleted using a :java:extdoc:`CriteriaDelete<javax.persistence.criteria.CriteriaDelete>` query.
+The entities are deleted using a :java-javax:`CriteriaDelete <javax/persistence/criteria/CriteriaDelete>` query.
 
 Because this deletes the entities directly from the database, we need to remove the deleted entities from the session manually.
 First the entities are removed from loaded collections in the session (see ``DeleteEntityHelper#removeFromLoadedCollections()``)
@@ -120,8 +120,8 @@ removed from the collection of the owning side of the association.
 That means that the deleted entity has to be removed from every many-to-many collection where the owning side is not
 the deleted entity.
 
-This is done by the :java:ref:`CustomDeleteEventListener<ch.tocco.nice2.persist.hibernate.cascade.CustomDeleteEventListener>`
-which is a subclass of Hibernate's default :java:extdoc:`DefaultDeleteEventListener<org.hibernate.event.internal.DefaultDeleteEventListener>`.
+This is done by the :abbr:`CustomDeleteEventListener (ch.tocco.nice2.persist.hibernate.cascade.CustomDeleteEventListener)`
+which is a subclass of Hibernate's default :java-hibernate:`DefaultDeleteEventListener <org/hibernate/event/internal/DefaultDeleteEventListener>`.
 
 .. note::
 

--- a/framework/architecture/hibernate/entity-tuplizer.rst
+++ b/framework/architecture/hibernate/entity-tuplizer.rst
@@ -1,13 +1,13 @@
 Custom entity tuplizer
 ======================
 
-We use a custom :java:extdoc:`EntityTuplizer<org.hibernate.tuple.entity.EntityTuplizer>`
-(:java:ref:`CustomEntityTuplizer<ch.tocco.nice2.persist.hibernate.CustomEntityTuplizer>`) to support the following features:
+We use a custom :java-hibernate:`EntityTuplizer <org/hibernate/tuple/entity/EntityTuplizer>`
+(:abbr:`CustomEntityTuplizer (ch.tocco.nice2.persist.hibernate.CustomEntityTuplizer)`) to support the following features:
 
 Lazy initialization of proxy factories
 --------------------------------------
 
-Hibernate creates a :java:extdoc:`ProxyFactory<org.hibernate.proxy.ProxyFactory>` for each entity class.
+Hibernate creates a :java-hibernate:`ProxyFactory <org/hibernate/proxy/ProxyFactory>` for each entity class.
 To improve the startup time of the application we create them lazily when they are needed for the first time.
 In addition this saves some memory as, most likely, proxies are not created for every entity class we use.
 
@@ -17,22 +17,22 @@ first time.
 Custom proxy factory
 --------------------
 
-We use our own custom :java:extdoc:`JavassistProxyFactory<org.hibernate.proxy.pojo.javassist.JavassistProxyFactory>`
-(:java:ref:`NiceJavassistProxyFactory<ch.tocco.nice2.persist.hibernate.proxy.NiceJavassistProxyFactory>`) that uses
-the :java:ref:`NiceJavassistLazyInitializer<ch.tocco.nice2.persist.hibernate.proxy.NiceJavassistLazyInitializer>` as
-:java:extdoc:`LazyInitializer<org.hibernate.proxy.LazyInitializer>`.
+We use our own custom :java-hibernate:`JavassistProxyFactory <org/hibernate/proxy/pojo/javassist/JavassistProxyFactory>`
+(:abbr:`NiceJavassistProxyFactory (ch.tocco.nice2.persist.hibernate.proxy.NiceJavassistProxyFactory)`) that uses
+the :abbr:`NiceJavassistLazyInitializer (ch.tocco.nice2.persist.hibernate.proxy.NiceJavassistLazyInitializer)` as
+:java-hibernate:`LazyInitializer <org/hibernate/proxy/LazyInitializer>`.
 
 The lazy initializer contains the entity class and the identifier and by default initializes (i.e loads the data from the
 database) when any method is called on the proxy.
-However many methods of the :java:ref:`Entity<ch.tocco.nice2.persist.entity.Entity>` interface do not require the information
+However many methods of the :abbr:`Entity (ch.tocco.nice2.persist.entity.Entity)` interface do not require the information
 from the database and would trigger an unnecessary proxy initialization.
 
 Our custom lazy initializer prevents this and evaluates certain methods without initializing the proxy:
 
-    * ``requireKey()`` / ``getKey()``: the identifier is contained by the initializer and can be returned as :java:ref:`PrimaryKey<ch.tocco.nice2.persist.entity.PrimaryKey>`
+    * ``requireKey()`` / ``getKey()``: the identifier is contained by the initializer and can be returned as :abbr:`PrimaryKey (ch.tocco.nice2.persist.entity.PrimaryKey)`
     * ``hasKey()``: always returns true because proxies always belong to persistent entities
-    * ``getContext()`` / ``getManager()`` / ``getModel()``: the :java:ref:`DataModel<ch.tocco.nice2.persist.model.DataModel>`
-      and :java:ref:`Context<ch.tocco.nice2.persist.Context>` are injected into our custom initializer and can be returned directly or
+    * ``getContext()`` / ``getManager()`` / ``getModel()``: the :abbr:`DataModel (ch.tocco.nice2.persist.model.DataModel)`
+      and :abbr:`Context (ch.tocco.nice2.persist.Context)` are injected into our custom initializer and can be returned directly or
       used in combination with the persistent class to evaluate these methods
 
 Some additional methods are evaluated directly by the initializer only when the proxy is not initialized yet:

--- a/framework/architecture/hibernate/generated-values.rst
+++ b/framework/architecture/hibernate/generated-values.rst
@@ -3,25 +3,25 @@
 Automatically generated values
 ==============================
 
-For data types whose values should be created or updated automatically a :java:ref:`FieldGenerator<ch.tocco.nice2.persist.hibernate.pojo.FieldGenerator>`
+For data types whose values should be created or updated automatically a :abbr:`FieldGenerator (ch.tocco.nice2.persist.hibernate.pojo.FieldGenerator)`
 can be contributed.
 The value of these fields are automatically created when a entity is inserted and/or updated.
-The :java:ref:`FieldGenerator<ch.tocco.nice2.persist.hibernate.pojo.FieldGenerator>` returns a :java:extdoc:`GenerationTiming<org.hibernate.tuple.GenerationTiming>` (defines if the value should
+The :abbr:`FieldGenerator (ch.tocco.nice2.persist.hibernate.pojo.FieldGenerator)` returns a :java-hibernate:`GenerationTiming <org/hibernate/tuple/GenerationTiming>` (defines if the value should
 be generated when the entity is created or when it is updated) and a supplier which generates the value.
 
 .. note:
 
-    For example the :java:ref:`CreationDateTimeFieldContribution<ch.tocco.nice2.userbase.types.CreationDateTimeFieldContribution>`
+    For example the :abbr:`CreationDateTimeFieldContribution (ch.tocco.nice2.userbase.types.CreationDateTimeFieldContribution)`
     is registered for the data type ``createts`` and creates a timestamp when a new entity is created.
 
 The field generators are stored in the :ref:`classLoaderService` so that they can be accessed through the session later on.
 
-If a field generator exists for a given data type, the :java:ref:`AlwaysGeneratedValue<ch.tocco.nice2.persist.hibernate.pojo.generator.AlwaysGeneratedValue>`
-annotation is added to this field (or the :java:ref:`InsertGeneratedValue<ch.tocco.nice2.persist.hibernate.pojo.generator.InsertGeneratedValue>`
+If a field generator exists for a given data type, the :abbr:`AlwaysGeneratedValue (ch.tocco.nice2.persist.hibernate.pojo.generator.AlwaysGeneratedValue)`
+annotation is added to this field (or the :abbr:`InsertGeneratedValue (ch.tocco.nice2.persist.hibernate.pojo.generator.InsertGeneratedValue)`
 if the value should only be generated once when the entity is first created). Both annotations take the data type as a mandatory parameter (see :ref:`generated-fields-annotations`).
 
-These annotations are themselves annotated with Hibernate's :java:extdoc:`ValueGenerationType<org.hibernate.annotations.ValueGenerationType>`
+These annotations are themselves annotated with Hibernate's :java-hibernate:`ValueGenerationType <org/hibernate/annotations/ValueGenerationType>`
 annotation (see `documentation <https://docs.jboss.org/hibernate/orm/5.2/userguide/html_single/Hibernate_User_Guide.html#mapping-generated-ValueGenerationType>`_).
-The :java:extdoc:`ValueGenerationType<org.hibernate.annotations.ValueGenerationType>` annotations refer to an implementation of :java:ref:`AbstractFieldGeneration<ch.tocco.nice2.persist.hibernate.pojo.generator.AbstractFieldGeneration>`
-which looks up the correct :java:ref:`FieldGenerator<ch.tocco.nice2.persist.hibernate.pojo.FieldGenerator>` in the session
+The :java-hibernate:`ValueGenerationType <org/hibernate/annotations/ValueGenerationType>` annotations refer to an implementation of :abbr:`AbstractFieldGeneration (ch.tocco.nice2.persist.hibernate.pojo.generator.AbstractFieldGeneration)`
+which looks up the correct :abbr:`FieldGenerator (ch.tocco.nice2.persist.hibernate.pojo.FieldGenerator)` in the session
 (depending on the data type) and generates the value.

--- a/framework/architecture/hibernate/introduction.rst
+++ b/framework/architecture/hibernate/introduction.rst
@@ -23,8 +23,8 @@ At first it is described how Hibernate is initialized (:doc:`session-factory-pro
 XML entity definitions are converted into Java classes (:doc:`entity-class-generation`).
 
 Next it is explained how the automatically generated Java classes implement the functionality of the
-:java:ref:`Entity<ch.tocco.nice2.persist.entity.Entity>` interface (:doc:`abstract-pojo-entity`) and how
-the :java:ref:`Relation<ch.tocco.nice2.persist.entity.Relation>` interface is mapped to the JPA associations
+:abbr:`Entity (ch.tocco.nice2.persist.entity.Entity)` interface (:doc:`abstract-pojo-entity`) and how
+the :abbr:`Relation (ch.tocco.nice2.persist.entity.Relation)` interface is mapped to the JPA associations
 (:doc:`collections`).
 
 There is additional in depth information available about the mapping of the data:
@@ -34,8 +34,8 @@ There is additional in depth information available about the mapping of the data
     * :doc:`entity-tuplizer`
     * :doc:`generated-values`
 
-The next chapters describes the lifecycle of the :java:ref:`Context<ch.tocco.nice2.persist.Context>` (:doc:`session-lifecycle`)
-and the :java:ref:`Transaction<ch.tocco.nice2.persist.tx.Transaction>` (:doc:`transaction-lifecycle` and :doc:`entity-transaction-context`).
+The next chapters describes the lifecycle of the :abbr:`Context (ch.tocco.nice2.persist.Context)` (:doc:`session-lifecycle`)
+and the :abbr:`Transaction (ch.tocco.nice2.persist.tx.Transaction)` (:doc:`transaction-lifecycle` and :doc:`entity-transaction-context`).
 
 It is also explained how the different kind of listeners are integrated into the persistence layer (:doc:`listeners`).
 

--- a/framework/architecture/hibernate/large-objects.rst
+++ b/framework/architecture/hibernate/large-objects.rst
@@ -3,53 +3,53 @@
 Large objects
 =============
 
-The :java:ref:`BinaryAccessProvider<ch.tocco.nice2.persist.spi.binary.BinaryAccessProvider>` provides access to
-:java:ref:`Binary<ch.tocco.nice2.persist.entity.Binary>` instances.
+The :abbr:`BinaryAccessProvider (ch.tocco.nice2.persist.spi.binary.BinaryAccessProvider)` provides access to
+:abbr:`Binary (ch.tocco.nice2.persist.entity.Binary)` instances.
 
 While the actual data may be saved to different data stores, the metadata is saved in the ``_nice_binary`` (and partially
 ``nice_resource``) table in Postgres.
 
 Currently there are two different implementations:
 
-    * The :java:ref:`DbBinaryAccessProvider<ch.tocco.nice2.persist.backend.jdbc.impl.DbBinaryAccessProvider>` is the default
+    * The :abbr:`DbBinaryAccessProvider (ch.tocco.nice2.persist.backend.jdbc.impl.DbBinaryAccessProvider)` is the default
       and stores the data in a large object of Postgres.
-    * The :java:ref:`S3AccessProvider<ch.tocco.nice2.optional.s3.storage.S3AccessProvider>` is provided by the ``optional/s3storage``
+    * The :abbr:`S3AccessProvider (ch.tocco.nice2.optional.s3.storage.S3AccessProvider)` is provided by the ``optional/s3storage``
       module and can access any S3 compatible data store. See also :doc:`../s3/s3`.
 
-The main task of a :java:ref:`BinaryAccessProvider<ch.tocco.nice2.persist.spi.binary.BinaryAccessProvider>` is to read,
-write and delete :java:ref:`Binary<ch.tocco.nice2.persist.entity.Binary>` instances.
+The main task of a :abbr:`BinaryAccessProvider (ch.tocco.nice2.persist.spi.binary.BinaryAccessProvider)` is to read,
+write and delete :abbr:`Binary (ch.tocco.nice2.persist.entity.Binary)` instances.
 
-The :java:ref:`AbstractBinaryAccessProvider<ch.tocco.nice2.persist.spi.binary.AbstractBinaryAccessProvider>` is the base class
+The :abbr:`AbstractBinaryAccessProvider (ch.tocco.nice2.persist.spi.binary.AbstractBinaryAccessProvider)` is the base class
 that handles all modifications of the ``_nice_binary`` table, while sub-classes save the actual binary data into their data store.
 
 Loading
 -------
 
-The method ``loadBinary(HashCode, Connection)`` is called from the :java:ref:`BinaryUserType<ch.tocco.nice2.persist.hibernate.usertype.BinaryUserType>`
+The method ``loadBinary(HashCode, Connection)`` is called from the :abbr:`BinaryUserType (ch.tocco.nice2.persist.hibernate.usertype.BinaryUserType)`
 and loads the binary in two steps:
 
-    * The metadata is loaded from the Postgres tables (that's why we need a :java:extdoc:`Connection<java.sql.Connection>`)
+    * The metadata is loaded from the Postgres tables (that's why we need a :java:`Connection <java/sql/Connection>`)
     * The actual binary data is lazily loaded when ``openStream()`` is called
 
 .. warning::
 
-    The :java:extdoc:`Connection<java.sql.Connection>` passed to this method belongs to the Hibernate transaction and
+    The :java:`Connection <java/sql/Connection>` passed to this method belongs to the Hibernate transaction and
     should never be committed manually!
 
-There is a second method ``loadBinary(HashCode, long, String, String)`` that can be used to create a :java:ref:`Binary<ch.tocco.nice2.persist.entity.Binary>` instance
+There is a second method ``loadBinary(HashCode, long, String, String)`` that can be used to create a :abbr:`Binary (ch.tocco.nice2.persist.entity.Binary)` instance
 without accessing the Postgres database, if the metadata is already known.
 
 Saving
 ------
 
-``storeBinary(Binary, Connection)`` saves a :java:ref:`Binary<ch.tocco.nice2.persist.entity.Binary>` instance to the data store.
+``storeBinary(Binary, Connection)`` saves a :abbr:`Binary (ch.tocco.nice2.persist.entity.Binary)` instance to the data store.
 Because the binary is referenced by its hash code, the same file is only saved once, even if it's referenced multiple times
 by the database.
 
 Therefore at first it is checked if this file already exists. If not, an entry in the ``_nice_binary`` table is created
 and then the data itself is saved to the data store.
 
-All changes made through the passed :java:extdoc:`Connection<java.sql.Connection>` are transactional and might be rolled back.
+All changes made through the passed :java:`Connection <java/sql/Connection>` are transactional and might be rolled back.
 
 Deleting
 --------
@@ -61,18 +61,18 @@ In order to know when the row can be safely deleted, a ``reference_count`` colum
 Objects Stored in DB
 ^^^^^^^^^^^^^^^^^^^^
 
-When the ``reference_count`` is zero, the binary will automatically be deleted by the :java:ref:`DeleteUnreferencedBinariesBatchJob<ch.tocco.nice2.dms.impl.maintenance.DeleteUnreferencedBinariesBatchJob>`.
+When the ``reference_count`` is zero, the binary will automatically be deleted by the :abbr:`DeleteUnreferencedBinariesBatchJob (ch.tocco.nice2.dms.impl.maintenance.DeleteUnreferencedBinariesBatchJob)`.
 The large object itself will be removed by the built-in `lo_manage`_ trigger.
 
 Objects Stored in S3
 ^^^^^^^^^^^^^^^^^^^^
 
-The :java:ref:`S3AccessProvider<ch.tocco.nice2.optional.s3.storage.S3AccessProvider>` is largely based on the functionality
+The :abbr:`S3AccessProvider (ch.tocco.nice2.optional.s3.storage.S3AccessProvider)` is largely based on the functionality
 above, but there are some differences:
 
     * Because S3 is independent of the JDBC transaction, there might be orphaned objects in the data store if the JDBC
       transaction is rolled back, after a new object has been stored.
-    * When a binary is removed (by the :java:ref:`DeleteUnreferencedBinariesBatchJob<ch.tocco.nice2.dms.impl.maintenance.DeleteUnreferencedBinariesBatchJob>`)
+    * When a binary is removed (by the :abbr:`DeleteUnreferencedBinariesBatchJob (ch.tocco.nice2.dms.impl.maintenance.DeleteUnreferencedBinariesBatchJob)`)
       it is only marked as deleted (column ``removed_at``) and removed later by an external tool.
     * S3 offers the possibility to create a `pre-signed URL`_ to an object that is valid for a certain amount of time (see ``Binary.Store#getUrl()``),
       this allows downloading the object directly from the S3 server instead of causing unnecessary traffic for the
@@ -81,8 +81,8 @@ above, but there are some differences:
 BinaryHashingService
 --------------------
 
-The :java:ref:`BinaryHashingService<ch.tocco.nice2.persist.binary.BinaryHashingService>` abstracts the conversion of a
-binary into its hash code. This allows different :java:ref:`BinaryAccessProvider<ch.tocco.nice2.persist.spi.binary.BinaryAccessProvider>`
+The :abbr:`BinaryHashingService (ch.tocco.nice2.persist.binary.BinaryHashingService)` abstracts the conversion of a
+binary into its hash code. This allows different :abbr:`BinaryAccessProvider (ch.tocco.nice2.persist.spi.binary.BinaryAccessProvider)`
 to use different hashing strategies.
 
     * ``hashFunction()`` defines the hash function to be used
@@ -91,7 +91,7 @@ to use different hashing strategies.
 BinaryDataAccessor
 ------------------
 
-The :java:ref:`BinaryDataAccessor<ch.tocco.nice2.persist.hibernate.binary.BinaryDataAccessor>` is a service to efficiently
+The :abbr:`BinaryDataAccessor (ch.tocco.nice2.persist.hibernate.binary.BinaryDataAccessor)` is a service to efficiently
 query the ``_nice_binary`` and ``nice_resource`` tables.
 
 This service is necessary, because currently the ``_nice_binary`` table is not mapped by Hibernate, which means it cannot

--- a/framework/architecture/hibernate/listeners.rst
+++ b/framework/architecture/hibernate/listeners.rst
@@ -9,21 +9,21 @@ and how they can be registered.
 EntityFacadeListener
 --------------------
 
-An :java:ref:`EntityFacadeListener<ch.tocco.nice2.persist.entity.events.EntityFacadeListener>` is called
+An :abbr:`EntityFacadeListener (ch.tocco.nice2.persist.entity.events.EntityFacadeListener)` is called
 immediately after certain entity operations (e.g. ``EntityManager#create()`` or ``Entity#setValue()``) and therefore
 this listener is independent of any hibernate functionality.
 
 Normally entity facade listeners are registered as hivemind services which then are injected into the
-:java:ref:`EntityFacadeListenerManagerImpl<ch.tocco.nice2.persist.hibernate.listener.EntityFacadeListenerManagerImpl>`,
+:abbr:`EntityFacadeListenerManagerImpl (ch.tocco.nice2.persist.hibernate.listener.EntityFacadeListenerManagerImpl)`,
 which manages all listeners and can also be used to fire events.
 
-It is also possible to temporarily register an :java:ref:`EntityFacadeListener<ch.tocco.nice2.persist.entity.events.EntityFacadeListener>` for the current context
+It is also possible to temporarily register an :abbr:`EntityFacadeListener (ch.tocco.nice2.persist.entity.events.EntityFacadeListener)` for the current context
 using ``Context#addEntityFacadeListener()``. These listeners will be called for every entity and will only be called
 for events of the context they belong to.
 Likewise it is possible to add a temporary listener using ``EntityManager#addEntityFacadeListener()`` which will only
 be called for events of this entity manager.
 
-When an event is fired, the :java:ref:`EntityFacadeListenerManagerImpl<ch.tocco.nice2.persist.hibernate.listener.EntityFacadeListenerManagerImpl>`
+When an event is fired, the :abbr:`EntityFacadeListenerManagerImpl (ch.tocco.nice2.persist.hibernate.listener.EntityFacadeListenerManagerImpl)`
 searches for all registered hivemind listeners (that accept events of the affected entity) as well as all listeners of the current context
 and entity manager.
 
@@ -31,7 +31,7 @@ and entity manager.
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 This event is fired directly after a new entity instance is created (no fields are set at this point) by the
-:java:ref:`EntityFactoryImpl<ch.tocco.nice2.persist.hibernate.pojo.EntityFactoryImpl>`. All entity instances
+:abbr:`EntityFactoryImpl (ch.tocco.nice2.persist.hibernate.pojo.EntityFactoryImpl)`. All entity instances
 are created by the entity factory (even those that are loaded from the database), but the event is only fired when a new instance
 is created by the user (not when an entity is loaded from the database). This is the case when no primary key is passed
 to the entity factory.
@@ -54,8 +54,8 @@ generated setter method.
 
 This event is fired every time a relation is modified (i.e. if an entity is added to or removed from a relation).
 This is done in ``AbstractRelationAdapter#fireRelationChangingEvent()`` which in turn is called by the
-:java:ref:`ToOneRelationAdapter<ch.tocco.nice2.persist.hibernate.pojo.relation.ToOneRelationAdapter>` and the
-:java:ref:`ToManyRelationAdapter<ch.tocco.nice2.persist.hibernate.pojo.relation.ToManyRelationAdapter>`.
+:abbr:`ToOneRelationAdapter (ch.tocco.nice2.persist.hibernate.pojo.relation.ToOneRelationAdapter)` and the
+:abbr:`ToManyRelationAdapter (ch.tocco.nice2.persist.hibernate.pojo.relation.ToManyRelationAdapter)`.
 An event is also always fired for the reverse side of the relation.
 
 See the chapter :doc:`abstract-pojo-entity` for a description when the ``adjusting`` flag is set to true.
@@ -73,56 +73,56 @@ anymore.
 EntityListener
 --------------
 
-An :java:ref:`EntityListener<ch.tocco.nice2.persist.entity.events.EntityListener>` is used to listen
+An :abbr:`EntityListener (ch.tocco.nice2.persist.entity.events.EntityListener)` is used to listen
 to 'after-commit' events. This means that these listeners are only called after a transaction has been
 successfully committed.
 
-For this purpose we use hibernate's :java:extdoc:`PostCommitInsertEventListener<org.hibernate.event.spi.PostCommitInsertEventListener>`,
-:java:extdoc:`PostCommitUpdateEventListener<org.hibernate.event.spi.PostCommitUpdateEventListener>` and
-:java:extdoc:`PostCommitDeleteEventListener<org.hibernate.event.spi.PostCommitDeleteEventListener>`.
+For this purpose we use hibernate's :java-hibernate:`PostCommitInsertEventListener <org/hibernate/event/spi/PostCommitInsertEventListener>`,
+:java-hibernate:`PostCommitUpdateEventListener <org/hibernate/event/spi/PostCommitUpdateEventListener>` and
+:java-hibernate:`PostCommitDeleteEventListener <org/hibernate/event/spi/PostCommitDeleteEventListener>`.
 
-These listener interfaces are implemented by :java:ref:`AfterCommitListenerImpl<ch.tocco.nice2.persist.hibernate.listener.AfterCommitListenerImpl>`,
-which delegates the hibernate events to the corresponding :java:ref:`EntityListener<ch.tocco.nice2.persist.entity.events.EntityListener>`.
+These listener interfaces are implemented by :abbr:`AfterCommitListenerImpl (ch.tocco.nice2.persist.hibernate.listener.AfterCommitListenerImpl)`,
+which delegates the hibernate events to the corresponding :abbr:`EntityListener (ch.tocco.nice2.persist.entity.events.EntityListener)`.
 This class is bound to the hibernate events ``POST_COMMIT_INSERT``, ``POST_COMMIT_UPDATE`` and ``POST_COMMIT_DELETE``
-(see :java:ref:`HibernateCoreBootstrapContribution<ch.tocco.nice2.persist.hibernate.bootstrap.HibernateCoreBootstrapContribution>`).
+(see :abbr:`HibernateCoreBootstrapContribution (ch.tocco.nice2.persist.hibernate.bootstrap.HibernateCoreBootstrapContribution)`).
 
 Listeners can either be contributed as hivemind services or registered temporarily through the ``Context`` or ``EntityManager``
 (same as the entity facade listener).
 
 Hibernate does not fire a ``POST_COMMIT_UPDATE`` for an entity if the only change is in a :term:`collection <hibernate collection>` and this collection is not the owning side of the association.
-For this special use case there is the :java:ref:`CustomFlushEntityEventListener<ch.tocco.nice2.persist.hibernate.listener.CustomFlushEntityEventListener>`.
+For this special use case there is the :abbr:`CustomFlushEntityEventListener (ch.tocco.nice2.persist.hibernate.listener.CustomFlushEntityEventListener)`.
 This is class is bound to the hibernate events ``FLUSH_ENTITY`` and checks every entity in the persistence context whether
 this event needs to be fired manually.
 If no event would be fired by hibernate but the entity has a change in (the non-owning side of) a :term:`collection <hibernate collection>`, the listener
-registers a :java:extdoc:`AfterTransactionCompletionProcess<org.hibernate.action.spi.AfterTransactionCompletionProcess>`
+registers a :java-hibernate:`AfterTransactionCompletionProcess <org/hibernate/action/spi/AfterTransactionCompletionProcess>`
 (the event should only be fired if the transaction was completed successfully),
-which fires the missing event manually, with the :java:extdoc:`ActionQueue<org.hibernate.engine.spi.ActionQueue>`.
+which fires the missing event manually, with the :java-hibernate:`ActionQueue <org/hibernate/engine/spi/ActionQueue>`.
 
 CommitListener
 --------------
 
-A :java:ref:`CommitListener<ch.tocco.nice2.persist.hibernate.listener.CommitListener>` listens to events that are fired
-just before or after a transaction is committed. The commit listeners are managed by the :java:ref:`EntityFacadeListenerManagerImpl<ch.tocco.nice2.persist.hibernate.listener.EntityFacadeListenerManagerImpl>`.
+A :abbr:`CommitListener (ch.tocco.nice2.persist.hibernate.listener.CommitListener)` listens to events that are fired
+just before or after a transaction is committed. The commit listeners are managed by the :abbr:`EntityFacadeListenerManagerImpl (ch.tocco.nice2.persist.hibernate.listener.EntityFacadeListenerManagerImpl)`.
 
 Commit listeners can be registered for the current context by calling ``Context#addCommitListener()``, which in turn
-registers the listener with the :java:ref:`EntityFacadeListenerManagerImpl<ch.tocco.nice2.persist.hibernate.listener.EntityFacadeListenerManagerImpl>`.
+registers the listener with the :abbr:`EntityFacadeListenerManagerImpl (ch.tocco.nice2.persist.hibernate.listener.EntityFacadeListenerManagerImpl)`.
 
-As the :java:ref:`EntityFacadeListenerManagerImpl<ch.tocco.nice2.persist.hibernate.listener.EntityFacadeListenerManagerImpl>` tracks
+As the :abbr:`EntityFacadeListenerManagerImpl (ch.tocco.nice2.persist.hibernate.listener.EntityFacadeListenerManagerImpl)` tracks
 all commit listeners by session in a map, it is important that they will be removed properly.
-To avoid memory leaks when the user forgets to remove a commit listener, a :java:extdoc:`SessionEventListener<org.hibernate.SessionEventListener>`,
+To avoid memory leaks when the user forgets to remove a commit listener, a :java-hibernate:`SessionEventListener <org/hibernate/SessionEventListener>`,
 which removes all commit listeners when the session ends, is registered once per session.
 
-The events are fired by the :java:ref:`TransactionControlImpl<ch.tocco.nice2.persist.hibernate.PersistenceServiceImpl.TransactionControlImpl>` (see :doc:`transaction-lifecycle`)
+The events are fired by the :abbr:`TransactionControlImpl (ch.tocco.nice2.persist.hibernate.PersistenceServiceImpl.TransactionControlImpl)` (see :doc:`transaction-lifecycle`)
 just before or after the database transaction is committed. ``CommitListener#onAfterCommit()`` is only called if the commit
 was successful.
 
 TransactionListener
 -------------------
 
-A :java:ref:`TransactionListener<ch.tocco.nice2.persist.hibernate.ch.tocco.nice2.persist.hibernate.TransactionListener>` is another
-listener that gets notified by transaction events. But in contrast to the :java:ref:`CommitListener<ch.tocco.nice2.persist.hibernate.listener.CommitListener>`
+A :abbr:`TransactionListener (ch.tocco.nice2.persist.hibernate.ch.tocco.nice2.persist.hibernate.TransactionListener)` is another
+listener that gets notified by transaction events. But in contrast to the :abbr:`CommitListener (ch.tocco.nice2.persist.hibernate.listener.CommitListener)`
 it is meant to be used internally by the persistence framework only.
-This is a replacement of the :java:ref:`TransactionAware<ch.tocco.nice2.persist.tx.TransactionAware>` of the old persistence
+This is a replacement of the :abbr:`TransactionAware (ch.tocco.nice2.persist.tx.TransactionAware)` of the old persistence
 implementation.
 
     - ``TransactionListener#onCommit()`` is called after ``CommitListener#onBeforeCommit()`` has already been called
@@ -130,5 +130,5 @@ implementation.
     - ``TransactionListener#onRollback()`` is called just before a transaction will be rolled back
     - ``TransactionListener#afterTransaction()`` is called after every transaction (whether successful or not), but before ``CommitListener#onAfterCommit()``
 
-A :java:ref:`TransactionListener<ch.tocco.nice2.persist.hibernate.ch.tocco.nice2.persist.hibernate.TransactionListener>` can be registered with
-the :java:ref:`TransactionControl<ch.tocco.nice2.persist.hibernate.TransactionControl>` of a transaction.
+A :abbr:`TransactionListener (ch.tocco.nice2.persist.hibernate.ch.tocco.nice2.persist.hibernate.TransactionListener)` can be registered with
+the :abbr:`TransactionControl (ch.tocco.nice2.persist.hibernate.TransactionControl)` of a transaction.

--- a/framework/architecture/hibernate/memory-management.rst
+++ b/framework/architecture/hibernate/memory-management.rst
@@ -2,8 +2,8 @@ Memory management
 =================
 
 The new persistence layer based on Hibernate behaves a bit differently when a lot of data is loaded.
-All entities that are loaded in a specific :java:ref:`Context<ch.tocco.nice2.persist.Context>` will be
-referenced by the :java:extdoc:`Session<org.hibernate.Session>` until it is closed, even after the transaction
+All entities that are loaded in a specific :abbr:`Context (ch.tocco.nice2.persist.Context)` will be
+referenced by the :java-hibernate:`Session <org/hibernate/Session>` until it is closed, even after the transaction
 is committed.
 When a lot of data is loaded or persisted within one action, the action should be split up into multiple transactions
 and contexts.
@@ -11,39 +11,39 @@ and contexts.
 PartitionedTask
 ---------------
 
-The easiest way to split a big task into multiple transactions is to use a :java:ref:`PartitionedTask<ch.tocco.nice2.persist.exec.PartitionedTask>`.
-A partitioned task is an extension of :java:ref:`PersistTask<ch.tocco.nice2.persist.exec.PersistTask>` and can be passed
-to the :java:ref:`CommandExecutor<ch.tocco.nice2.persist.exec.CommandExecutor>`.
+The easiest way to split a big task into multiple transactions is to use a :abbr:`PartitionedTask (ch.tocco.nice2.persist.exec.PartitionedTask)`.
+A partitioned task is an extension of :abbr:`PersistTask (ch.tocco.nice2.persist.exec.PersistTask)` and can be passed
+to the :abbr:`CommandExecutor (ch.tocco.nice2.persist.exec.CommandExecutor)`.
 
-The :java:ref:`PartitionedTask<ch.tocco.nice2.persist.exec.PartitionedTask>` requires an inner task, a subclass of :java:ref:`AbstractPartitionedPersistTask<ch.tocco.nice2.persist.exec.AbstractPartitionedPersistTask>`,
+The :abbr:`PartitionedTask (ch.tocco.nice2.persist.exec.PartitionedTask)` requires an inner task, a subclass of :abbr:`AbstractPartitionedPersistTask (ch.tocco.nice2.persist.exec.AbstractPartitionedPersistTask)`,
 that contains the execution logic.
 
-The :java:ref:`AbstractPartitionedPersistTask<ch.tocco.nice2.persist.exec.AbstractPartitionedPersistTask>` has the following functionality:
+The :abbr:`AbstractPartitionedPersistTask (ch.tocco.nice2.persist.exec.AbstractPartitionedPersistTask)` has the following functionality:
 
-    * A method ``partition()`` that converts it into a :java:ref:`PartitionedTask<ch.tocco.nice2.persist.exec.PartitionedTask>`,
-      which then can be passed to the :java:ref:`CommandExecutor<ch.tocco.nice2.persist.exec.CommandExecutor>` for memory safe
+    * A method ``partition()`` that converts it into a :abbr:`PartitionedTask (ch.tocco.nice2.persist.exec.PartitionedTask)`,
+      which then can be passed to the :abbr:`CommandExecutor (ch.tocco.nice2.persist.exec.CommandExecutor)` for memory safe
       execution.
 
-    * Managing the 'task data': Task data are :java:ref:`Context<ch.tocco.nice2.persist.Context>` dependent objects that
-      are required for every iteration (for example an :java:ref:`Entity<ch.tocco.nice2.persist.entity.Entity>`). Because a new context is initialized after a certain number
+    * Managing the 'task data': Task data are :abbr:`Context (ch.tocco.nice2.persist.Context)` dependent objects that
+      are required for every iteration (for example an :abbr:`Entity (ch.tocco.nice2.persist.entity.Entity)`). Because a new context is initialized after a certain number
       of iterations, these objects need to be reinitialized for each context. The task data object can be defined by overriding
       the ``createTaskData()`` method. During task execution it can be accessed using the ``getTaskData(Context)`` method.
       It is automatically cached for each context, and recreated when a new context is created.
 
 In addition to the inner task, it is possible to specify input and output transformation functions.
 Remember that context dependent objects (like entities) may not be used as input parameters, therefore
-:java:ref:`EntityId<ch.tocco.nice2.persist.entity.EntityId>` or :java:ref:`PrimaryKey<ch.tocco.nice2.persist.entity.PrimaryKey>`
+:abbr:`EntityId (ch.tocco.nice2.persist.entity.EntityId)` or :abbr:`PrimaryKey (ch.tocco.nice2.persist.entity.PrimaryKey)`
 should be used instead.
-To facilitate the conversion between these objects, a :java:extdoc:`BiFunction<java.util.function.BiFunction>` can be passed
+To facilitate the conversion between these objects, a :java:`BiFunction <java/util/function/BiFunction>` can be passed
 to the partitioned task. This function is executed each time a new partition is started and converts the input parameters before they
 are passed to the inner task.
 
-This means that it's possible to write the inner task using an :java:ref:`Entity<ch.tocco.nice2.persist.entity.Entity>`
-argument as usual, but pass :java:ref:`EntityId<ch.tocco.nice2.persist.entity.EntityId>` or :java:ref:`PrimaryKey<ch.tocco.nice2.persist.entity.PrimaryKey>`
-instances to the :java:ref:`PartitionedTask<ch.tocco.nice2.persist.exec.PartitionedTask>`.
+This means that it's possible to write the inner task using an :abbr:`Entity (ch.tocco.nice2.persist.entity.Entity)`
+argument as usual, but pass :abbr:`EntityId (ch.tocco.nice2.persist.entity.EntityId)` or :abbr:`PrimaryKey (ch.tocco.nice2.persist.entity.PrimaryKey)`
+instances to the :abbr:`PartitionedTask (ch.tocco.nice2.persist.exec.PartitionedTask)`.
 
 There are several standard transformation functions available, for example ``PartitionedTask#loadEntities()``.
-Similar functions are available for the output value, for example to convert an :java:ref:`Entity<ch.tocco.nice2.persist.entity.Entity>` to an :java:ref:`EntityId<ch.tocco.nice2.persist.entity.EntityId>`.
+Similar functions are available for the output value, for example to convert an :abbr:`Entity (ch.tocco.nice2.persist.entity.Entity)` to an :abbr:`EntityId (ch.tocco.nice2.persist.entity.EntityId)`.
 
 The final argument is the size of the transaction, that is, how many iterations should be completed before a new
 context is created.
@@ -54,42 +54,42 @@ context is created.
     ``flush()`` and then ``clear()`` the session, without committing the transaction, however this is not available in the Tocco API yet
     (it's not clear which listeners to invoke on a ``flush()``).
 
-Internally the :java:ref:`PartitionedTask<ch.tocco.nice2.persist.exec.PartitionedTask>` simply splits the input arguments
+Internally the :abbr:`PartitionedTask (ch.tocco.nice2.persist.exec.PartitionedTask)` simply splits the input arguments
 into partitions of the given transaction size.
-For each partition a new :java:ref:`Context<ch.tocco.nice2.persist.Context>` created. Then the input transformation function
+For each partition a new :abbr:`Context (ch.tocco.nice2.persist.Context)` created. Then the input transformation function
 is applied and the inner task is executed.
 After that the output transformation is applied to the result and the context is closed.
 
 EntityList
 ----------
 
-The behaviour of the different :java:ref:`EntityList<ch.tocco.nice2.persist.entity.EntityList>` implementations is a
+The behaviour of the different :abbr:`EntityList (ch.tocco.nice2.persist.entity.EntityList)` implementations is a
 bit different compared to the old persistence layer.
 
 EntityListImpl
 ^^^^^^^^^^^^^^
 
-The :java:ref:`EntityListImpl<ch.tocco.nice2.persist.hibernate.pojo.EntityListImpl>` is the default implementation.
-It is based on a :java:extdoc:`List<java.util.List>` of :java:ref:`Entity<ch.tocco.nice2.persist.entity.Entity>` instances.
+The :abbr:`EntityListImpl (ch.tocco.nice2.persist.hibernate.pojo.EntityListImpl)` is the default implementation.
+It is based on a :java:`List <java/util/List>` of :abbr:`Entity (ch.tocco.nice2.persist.entity.Entity)` instances.
 These entities are already loaded, that means this implementation should not be used for very large lists, otherwise a lot of
 memory will be required.
 
-The :java:ref:`EntityListImpl<ch.tocco.nice2.persist.hibernate.pojo.EntityListImpl>` is mainly used as a result of the
-``execute()`` method of the :java:ref:`Query<ch.tocco.nice2.persist.query.Query>` class.
+The :abbr:`EntityListImpl (ch.tocco.nice2.persist.hibernate.pojo.EntityListImpl)` is mainly used as a result of the
+``execute()`` method of the :abbr:`Query (ch.tocco.nice2.persist.query.Query)` class.
 
 .. note::
 
     Queries that are expected to have a lot of result rows should not use the ``execute()`` method. Instead ``getKeys()``
-    or the :java:ref:`PathQueryBuilder<ch.tocco.nice2.persist.hibernate.query.builder.PathQueryBuilder>` should be used
-    (perhaps in combination with a :java:ref:`PartitionedTask<ch.tocco.nice2.persist.exec.PartitionedTask>`).
+    or the :abbr:`PathQueryBuilder (ch.tocco.nice2.persist.hibernate.query.builder.PathQueryBuilder)` should be used
+    (perhaps in combination with a :abbr:`PartitionedTask (ch.tocco.nice2.persist.exec.PartitionedTask)`).
 
 LazyEntityList
 ^^^^^^^^^^^^^^
 
-The :java:ref:`LazyEntityList<ch.tocco.nice2.persist.hibernate.LazyEntityList>` is based on a :java:ref:`PrimaryKeyList<ch.tocco.nice2.persist.entity.PrimaryKeyList>`.
+The :abbr:`LazyEntityList (ch.tocco.nice2.persist.hibernate.LazyEntityList)` is based on a :abbr:`PrimaryKeyList (ch.tocco.nice2.persist.entity.PrimaryKeyList)`.
 No entities are loaded unless required and ``getKeys()`` can be called without any additional queries.
 
-When an :java:ref:`Entity<ch.tocco.nice2.persist.entity.Entity>` is accessed, a number (see ``setPageSize()``) of entities
+When an :abbr:`Entity (ch.tocco.nice2.persist.entity.Entity)` is accessed, a number (see ``setPageSize()``) of entities
 is loaded together.
 
 This implementation works well, when only ``getKeys()`` (or only a few entities) are accessed. Also, it does not unnecessarily
@@ -98,22 +98,22 @@ load all entities, even when they are never used later.
 However the loaded entities are always referenced by the list (and context) and high memory usage is still possible when
 the entire list is loaded.
 
-The :java:ref:`LazyEntityList<ch.tocco.nice2.persist.hibernate.LazyEntityList>` is returned from ``EntityManager#createEntityList(PrimaryKey...)``
+The :abbr:`LazyEntityList (ch.tocco.nice2.persist.hibernate.LazyEntityList)` is returned from ``EntityManager#createEntityList(PrimaryKey...)``
 and ``PrimaryKeyList#toEntityList()``.
 
 MemoryEfficientLazyEntityList
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The :java:ref:`MemoryEfficientLazyEntityList<ch.tocco.nice2.persist.hibernate.MemoryEfficientLazyEntityList>` is also based on a
-:java:ref:`PrimaryKeyList<ch.tocco.nice2.persist.entity.PrimaryKeyList>` and is based on pages like the
-:java:ref:`LazyEntityList<ch.tocco.nice2.persist.hibernate.LazyEntityList>`.
+The :abbr:`MemoryEfficientLazyEntityList (ch.tocco.nice2.persist.hibernate.MemoryEfficientLazyEntityList)` is also based on a
+:abbr:`PrimaryKeyList (ch.tocco.nice2.persist.entity.PrimaryKeyList)` and is based on pages like the
+:abbr:`LazyEntityList (ch.tocco.nice2.persist.hibernate.LazyEntityList)`.
 
-The difference is that in the :java:ref:`MemoryEfficientLazyEntityList<ch.tocco.nice2.persist.hibernate.MemoryEfficientLazyEntityList>`
-only one page is loaded at the same time. Each page is loaded with a new :java:ref:`Context<ch.tocco.nice2.persist.Context>`,
-the previous :java:ref:`Context<ch.tocco.nice2.persist.Context>` is closed as soon as a new page is loaded.
+The difference is that in the :abbr:`MemoryEfficientLazyEntityList (ch.tocco.nice2.persist.hibernate.MemoryEfficientLazyEntityList)`
+only one page is loaded at the same time. Each page is loaded with a new :abbr:`Context (ch.tocco.nice2.persist.Context)`,
+the previous :abbr:`Context (ch.tocco.nice2.persist.Context)` is closed as soon as a new page is loaded.
 
-This implementation implements the :java:extdoc:`AutoCloseable<java.lang.AutoCloseable>` interface and should be used with the
-try-with-resources pattern so that the last :java:ref:`Context<ch.tocco.nice2.persist.Context>` is closed properly.
+This implementation implements the :java:`AutoCloseable <java/lang/AutoCloseable>` interface and should be used with the
+try-with-resources pattern so that the last :abbr:`Context (ch.tocco.nice2.persist.Context)` is closed properly.
 
 This list can be used with very large sizes, because the memory of the previous page is freed when a new page is loaded
 (or ``close()`` is called on the list).
@@ -123,18 +123,18 @@ This list can be used with very large sizes, because the memory of the previous 
     This list is only efficient when its elements are accessed in the given order. If the elements are accessed randomly,
     too many data is loaded from the database.
 
-    :java:ref:`Entity<ch.tocco.nice2.persist.entity.Entity>` instances obtained from this list should only be used within
-    the loop and primarily for read-only operations. As soon as its :java:ref:`Context<ch.tocco.nice2.persist.Context>`
+    :abbr:`Entity (ch.tocco.nice2.persist.entity.Entity)` instances obtained from this list should only be used within
+    the loop and primarily for read-only operations. As soon as its :abbr:`Context (ch.tocco.nice2.persist.Context)`
     is closed, it's no longer possible to participate in a transaction or to load associations.
 
 PrimaryKeyList
 ^^^^^^^^^^^^^^
 
-The :java:ref:`PrimaryKeyList<ch.tocco.nice2.persist.entity.PrimaryKeyList>` is basically a ``List<PrimaryKey>``
+The :abbr:`PrimaryKeyList (ch.tocco.nice2.persist.entity.PrimaryKeyList)` is basically a ``List<PrimaryKey>``
 with the following additional methods:
 
-    * ``getModel()`` returns the corresponding :java:ref:`EntityModel<ch.tocco.nice2.persist.model.EntityModel>`
-    * ``toEntityList()`` returns a :java:ref:`LazyEntityList<ch.tocco.nice2.persist.hibernate.LazyEntityList>` based on the keys of the list
+    * ``getModel()`` returns the corresponding :abbr:`EntityModel (ch.tocco.nice2.persist.model.EntityModel)`
+    * ``toEntityList()`` returns a :abbr:`LazyEntityList (ch.tocco.nice2.persist.hibernate.LazyEntityList)` based on the keys of the list
 
 It should be used where it can be expected that the size of the list is potentially very large, to indicate to the developer
 that it's probably not a good idea to load all entities at once.

--- a/framework/architecture/hibernate/new-api.rst
+++ b/framework/architecture/hibernate/new-api.rst
@@ -1,7 +1,7 @@
 New Persistence API
 ===================
 
-In addition to the current persistence API (based on the :java:ref:`Context<ch.tocco.nice2.persist.Context>` class)
+In addition to the current persistence API (based on the :abbr:`Context (ch.tocco.nice2.persist.Context)` class)
 there is a new API that offers features that are not available in the old API.
 
 .. warning::
@@ -11,17 +11,17 @@ there is a new API that offers features that are not available in the old API.
 PersistenceService
 ------------------
 
-The :java:ref:`PersistenceService<ch.tocco.nice2.persist.hibernate.PersistenceService>` is the core of the new API
+The :abbr:`PersistenceService (ch.tocco.nice2.persist.hibernate.PersistenceService)` is the core of the new API
 and provides type safe access to the persistence layer.
-In contrast to the :java:ref:`Context<ch.tocco.nice2.persist.Context>` of the old API that only works with entity names,
-the :java:ref:`PersistenceService<ch.tocco.nice2.persist.hibernate.PersistenceService>` also accepts entity classes and
+In contrast to the :abbr:`Context (ch.tocco.nice2.persist.Context)` of the old API that only works with entity names,
+the :abbr:`PersistenceService (ch.tocco.nice2.persist.hibernate.PersistenceService)` also accepts entity classes and
 returns an entity instance of the given class.
 This cannot be used directly yet, because all entity classes are generated at startup and therefore cannot be referenced
-by the code. However this functionality is currently used by the :java:ref:`QueryExecutor<ch.tocco.nice2.scripting.groovy.variable.QueryExecutor>`
+by the code. However this functionality is currently used by the :abbr:`QueryExecutor (ch.tocco.nice2.scripting.groovy.variable.QueryExecutor)`
 that is available in groovy scripted listeners to provide statically compiled, type safe access to the entities.
 
-In addition the :java:ref:`PersistenceService<ch.tocco.nice2.persist.hibernate.PersistenceService>` provides access
-to the different query builder implementations. In addition to the standard query builder that returns :java:ref:`Entity<ch.tocco.nice2.persist.entity.Entity>`
+In addition the :abbr:`PersistenceService (ch.tocco.nice2.persist.hibernate.PersistenceService)` provides access
+to the different query builder implementations. In addition to the standard query builder that returns :abbr:`Entity (ch.tocco.nice2.persist.entity.Entity)`
 instances, there are other query builders that can select sub-paths directly and efficiently.
 
 See :ref:`query_builder` for more information about this topic.
@@ -29,26 +29,26 @@ See :ref:`query_builder` for more information about this topic.
 PrimaryKeyLoader
 ^^^^^^^^^^^^^^^^
 
-The :java:ref:`PrimaryKeyLoader<ch.tocco.nice2.persist.hibernate.interceptor.PrimaryKeyLoader>` is used to load
+The :abbr:`PrimaryKeyLoader (ch.tocco.nice2.persist.hibernate.interceptor.PrimaryKeyLoader)` is used to load
 an entity by primary key. It is used when ``PersistenceService#retrieve()`` or ``EntityManager#get()`` is called.
 
-The default implementation :java:ref:`DefaultPrimaryKeyLoader<ch.tocco.nice2.persist.hibernate.pojo.PersistenceServiceImpl.DefaultPrimaryKeyLoader>`
+The default implementation :abbr:`DefaultPrimaryKeyLoader (ch.tocco.nice2.persist.hibernate.pojo.PersistenceServiceImpl.DefaultPrimaryKeyLoader)`
 uses the query builder to load the entity. This makes sure that the security conditions are always applied when an entity is loaded.
 
 We cannot use Hibernate's ``Session#get()`` directly (even is we use a custom event listener that adds security conditions),
 because it caches the results for the duration of the session. So if an entity is loaded in privileged mode first, it will
 always remain accessible even if the privileged mode has ended.
 
-There is also a special implementation for entity-docs (:java:ref:`EntityDocsPrimaryKeyLoader<ch.tocco.nice2.dms.impl.entitydocs.interceptor.EntityDocsPrimaryKeyLoader>`).
+There is also a special implementation for entity-docs (:abbr:`EntityDocsPrimaryKeyLoader (ch.tocco.nice2.dms.impl.entitydocs.interceptor.EntityDocsPrimaryKeyLoader)`).
 They need to be treated separately, as there are no ACL rules for them.
 
 Metamodel
 ---------
 
-The :java:ref:`Metamodel<ch.tocco.nice2.persist.hibernate.metamodel.Metamodel>` provides additional information about the data model
-that is not available in the :java:ref:`DataModel<ch.tocco.nice2.persist.model.DataModel>`.
+The :abbr:`Metamodel (ch.tocco.nice2.persist.hibernate.metamodel.Metamodel)` provides additional information about the data model
+that is not available in the :abbr:`DataModel (ch.tocco.nice2.persist.model.DataModel)`.
 
 Currently the only functionality is to get the ``sql type`` of an entity field. This is used by the
-:java:ref:`SchemaModelValidatorTask<ch.tocco.nice2.persist.backend.jdbc.impl.validate.SchemaModelValidatorTask>`
+:abbr:`SchemaModelValidatorTask (ch.tocco.nice2.persist.backend.jdbc.impl.validate.SchemaModelValidatorTask)`
 which checks if the database schema is compatible with the JPA schema.
 

--- a/framework/architecture/hibernate/query-builder.rst
+++ b/framework/architecture/hibernate/query-builder.rst
@@ -5,23 +5,23 @@ Query Builder
 
 There are currently 4 different query builders for different query types:
 
-    * The :java:ref:`EntityQueryBuilderImpl<ch.tocco.nice2.persist.hibernate.query.EntityQueryBuilderImpl>` builds queries that
-      return :java:ref:`Entity<ch.tocco.nice2.persist.entity.Entity>` instances. It is convenient to use the :java:ref:`Entity<ch.tocco.nice2.persist.entity.Entity>`
+    * The :abbr:`EntityQueryBuilderImpl (ch.tocco.nice2.persist.hibernate.query.EntityQueryBuilderImpl)` builds queries that
+      return :abbr:`Entity (ch.tocco.nice2.persist.entity.Entity)` instances. It is convenient to use the :abbr:`Entity (ch.tocco.nice2.persist.entity.Entity)`
       interface, but it might have a performance impact when too much data is loaded or too many queries are executed.
-    * The :java:ref:`SinglePathQueryBuilderImpl<ch.tocco.nice2.persist.hibernate.query.SinglePathQueryBuilderImpl>` can be used to
+    * The :abbr:`SinglePathQueryBuilderImpl (ch.tocco.nice2.persist.hibernate.query.SinglePathQueryBuilderImpl)` can be used to
       fetch exactly one property or path of an entity (for example to get all primary keys of a given query). This avoids
-      unnecessarily loading the entire :java:ref:`Entity<ch.tocco.nice2.persist.entity.Entity>`.
-    * The :java:ref:`PathQueryBuilderImpl<ch.tocco.nice2.persist.hibernate.query.PathQueryBuilderImpl>` is similar to the :java:ref:`SinglePathQueryBuilderImpl<ch.tocco.nice2.persist.hibernate.query.SinglePathQueryBuilderImpl>`
+      unnecessarily loading the entire :abbr:`Entity (ch.tocco.nice2.persist.entity.Entity)`.
+    * The :abbr:`PathQueryBuilderImpl (ch.tocco.nice2.persist.hibernate.query.PathQueryBuilderImpl)` is similar to the :abbr:`SinglePathQueryBuilderImpl (ch.tocco.nice2.persist.hibernate.query.SinglePathQueryBuilderImpl)`
       but can select more than one path and always returns a container object (currently ``Object[]`` and ``Map`` are supported)  as a result.
-    * The :java:ref:`CriteriaCountQueryBuilder<ch.tocco.nice2.persist.hibernate.query.CriteriaCountQueryBuilder>` can be
+    * The :abbr:`CriteriaCountQueryBuilder (ch.tocco.nice2.persist.hibernate.query.CriteriaCountQueryBuilder)` can be
       used to execute ``COUNT`` queries.
 
-In addition there is the :java:ref:`SubqueryBuilderImpl<ch.tocco.nice2.persist.hibernate.query.SubqueryBuilderImpl>` which is used
-to create sub-queries. An instance of this can be acquired from the :java:ref:`SubqueryFactory<ch.tocco.nice2.persist.hibernate.query.PredicateBuilder.SubqueryFactory>`
+In addition there is the :abbr:`SubqueryBuilderImpl (ch.tocco.nice2.persist.hibernate.query.SubqueryBuilderImpl)` which is used
+to create sub-queries. An instance of this can be acquired from the :abbr:`SubqueryFactory (ch.tocco.nice2.persist.hibernate.query.PredicateBuilder.SubqueryFactory)`
 of another query builder.
 
 Internally, JPA Criteria Queries are used. The reason for the query builder
-classes is that the user should not have access to the :java:extdoc:`Session<org.hibernate.Session>` object to make
+classes is that the user should not have access to the :java-hibernate:`Session <org/hibernate/Session>` object to make
 sure that all query interceptors (security and more) are always applied.
 
 Parts of the JPA Criteria API can still be used however, for example to specify conditions.
@@ -31,8 +31,8 @@ A tutorial can be found here: https://www.ibm.com/developerworks/java/library/j-
     The metamodel classes are currently not available, which means typesafe queries are not possible
     at the moment.
 
-All query builders can be obtained from the :java:ref:`PersistenceService<ch.tocco.nice2.persist.hibernate.PersistenceService>`.
-In addition the :java:ref:`QueryBuilderFactory<ch.tocco.nice2.persist.hibernate.query.builder.QueryBuilderFactory>` provides
+All query builders can be obtained from the :abbr:`PersistenceService (ch.tocco.nice2.persist.hibernate.PersistenceService)`.
+In addition the :abbr:`QueryBuilderFactory (ch.tocco.nice2.persist.hibernate.query.builder.QueryBuilderFactory)` provides
 several helper methods to create query builders.
 
 Implementation
@@ -41,22 +41,22 @@ Implementation
 ch.tocco.nice2.persist.hibernate.query.QueryBuilderBaseImpl
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The :java:ref:`QueryBuilderBaseImpl<ch.tocco.nice2.persist.hibernate.query.QueryBuilderBaseImpl>` is the base class for all query
+The :abbr:`QueryBuilderBaseImpl (ch.tocco.nice2.persist.hibernate.query.QueryBuilderBaseImpl)` is the base class for all query
 builders.
-It contains a list of :java:extdoc:`Predicate<javax.persistence.criteria.Predicate>` instances and provides several ways to add a
+It contains a list of :java-javax:`Predicate <javax/persistence/criteria/Predicate>` instances and provides several ways to add a
 condition to the query:
 
-    * Use ``QueryBuilderBase#where(Predicate...)`` to add a JPA :java:extdoc:`Predicate<javax.persistence.criteria.Predicate>` instance
-    * The :java:ref:`PredicateBuilder<ch.tocco.nice2.persist.hibernate.query.PredicateBuilder>` is a functional interface that
-      can be used to create :java:extdoc:`Predicate<javax.persistence.criteria.Predicate>` instances using lambda expressions
-      that can be passed to ``QueryBuilderBase#where(PredicateBuilder)``. The :java:extdoc:`CriteriaBuilder<javax.persistence.criteria.CriteriaBuilder>`,
-      :java:extdoc:`Root<javax.persistence.criteria.Root>`, :java:ref:`FieldAccessor<ch.tocco.nice2.persist.hibernate.query.ch.tocco.nice2.persist.hibernate.query.FieldAccessor>` :java:ref:`SubqueryFactory<ch.tocco.nice2.persist.hibernate.query.PredicateBuilder.SubqueryFactory>`
+    * Use ``QueryBuilderBase#where(Predicate...)`` to add a JPA :java-javax:`Predicate <javax/persistence/criteria/Predicate>` instance
+    * The :abbr:`PredicateBuilder (ch.tocco.nice2.persist.hibernate.query.PredicateBuilder)` is a functional interface that
+      can be used to create :java-javax:`Predicate <javax/persistence/criteria/Predicate>` instances using lambda expressions
+      that can be passed to ``QueryBuilderBase#where(PredicateBuilder)``. The :java-javax:`CriteriaBuilder <javax/persistence/criteria/CriteriaBuilder>`,
+      :java-javax:`Root <javax/persistence/criteria/Root>`, :abbr:`FieldAccessor (ch.tocco.nice2.persist.hibernate.query.ch.tocco.nice2.persist.hibernate.query.FieldAccessor)` :abbr:`SubqueryFactory (ch.tocco.nice2.persist.hibernate.query.PredicateBuilder.SubqueryFactory)`
       and the query hints are passed as parameters into the lambda expression.
-    * :java:ref:`Node<ch.tocco.nice2.conditionals.tree.Node>` or :java:ref:`Condition<ch.tocco.nice2.persist.qb2.Condition>` instances (created by the :java:ref:`Conditions<ch.tocco.nice2.persist.qb2.Conditions>` API)
+    * :abbr:`Node (ch.tocco.nice2.conditionals.tree.Node)` or :abbr:`Condition (ch.tocco.nice2.persist.qb2.Condition)` instances (created by the :abbr:`Conditions (ch.tocco.nice2.persist.qb2.Conditions)` API)
       can also be passed to ``QueryBuilderBase#where(Condition...)``. This API is also used by the security conditions.
-      A :java:ref:`Condition<ch.tocco.nice2.persist.qb2.Condition>` is first converted into a :java:ref:`Node<ch.tocco.nice2.conditionals.tree.Node>`
-      instance using the :java:ref:`ConditionFactory<ch.tocco.nice2.persist.query.ConditionFactory>` and then transformed into a
-      :java:extdoc:`Predicate<javax.persistence.criteria.Predicate>` using the :java:ref:`PredicateFactory<ch.tocco.nice2.persist.hibernate.PredicateFactory>`.
+      A :abbr:`Condition (ch.tocco.nice2.persist.qb2.Condition)` is first converted into a :abbr:`Node (ch.tocco.nice2.conditionals.tree.Node)`
+      instance using the :abbr:`ConditionFactory (ch.tocco.nice2.persist.query.ConditionFactory)` and then transformed into a
+      :java-javax:`Predicate <javax/persistence/criteria/Predicate>` using the :abbr:`PredicateFactory (ch.tocco.nice2.persist.hibernate.PredicateFactory)`.
     * Conditions added through the ``whereInsecure()`` methods are added in ``insecure`` mode (the ``isInsecure`` flag passed to ``QueryBuilderInterceptor#buildConditionFor()``
       and ``QueryBuilderInterceptor#fieldUsedInQueryCondition()`` is set to true) - this means that no ACL conditions will be added to any joins or subqueries that are present in the condition.
       The separate ``whereInsecure()`` method is necessary for security reasons to control where insecure conditions may be used, otherwise
@@ -79,11 +79,11 @@ generic parameter ``QW``.
 ch.tocco.nice2.persist.hibernate.query.AbstractCriteriaBuilder
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The :java:ref:`AbstractCriteriaBuilder<ch.tocco.nice2.persist.hibernate.query.AbstractCriteriaBuilder>` is the base class
-for all query builders that depend on a :java:extdoc:`CriteriaQuery<javax.persistence.criteria.CriteriaQuery>`.
+The :abbr:`AbstractCriteriaBuilder (ch.tocco.nice2.persist.hibernate.query.AbstractCriteriaBuilder)` is the base class
+for all query builders that depend on a :java-javax:`CriteriaQuery <javax/persistence/criteria/CriteriaQuery>`.
 
-It initializes a :java:extdoc:`CriteriaQuery<javax.persistence.criteria.CriteriaQuery>`, :java:extdoc:`CriteriaBuilder<javax.persistence.criteria.CriteriaBuilder>`,
-:java:extdoc:`Root<javax.persistence.criteria.Root>` and :java:ref:`SubqueryFactory<ch.tocco.nice2.persist.hibernate.query.PredicateBuilder.SubqueryFactory>`
+It initializes a :java-javax:`CriteriaQuery <javax/persistence/criteria/CriteriaQuery>`, :java-javax:`CriteriaBuilder <javax/persistence/criteria/CriteriaBuilder>`,
+:java-javax:`Root <javax/persistence/criteria/Root>` and :abbr:`SubqueryFactory (ch.tocco.nice2.persist.hibernate.query.PredicateBuilder.SubqueryFactory)`
 using the ``entityClass`` (the entity that should be queried) and ``queryType`` (the result type of the query) constructor parameters.
 
 This class also contains a map of parameters that are manually added to the query by the user and provides a helper method
@@ -92,37 +92,37 @@ to apply the parameters to the query.
 Parameter handling
 ~~~~~~~~~~~~~~~~~~
 
-A condition like ``field("name").is(value)`` might be mapped with a :java:extdoc:`ParameterExpression<javax.persistence.criteria.ParameterExpression>`
-even though the user specified the value directly. These parameters are collected and added to the query by the :java:ref:`ParameterCollector<ch.tocco.nice2.persist.impl.qb2.ParameterCollector>`.
+A condition like ``field("name").is(value)`` might be mapped with a :java-javax:`ParameterExpression <javax/persistence/criteria/ParameterExpression>`
+even though the user specified the value directly. These parameters are collected and added to the query by the :abbr:`ParameterCollector (ch.tocco.nice2.persist.impl.qb2.ParameterCollector)`.
 
-The parameter collector is a visitor for :java:ref:`Node<ch.tocco.nice2.conditionals.tree.Node>` objects. It sets an unique
+The parameter collector is a visitor for :abbr:`Node (ch.tocco.nice2.conditionals.tree.Node)` objects. It sets an unique
 name to all parameter nodes and collects their values.
 
-The :java:ref:`ParameterCollector<ch.tocco.nice2.persist.impl.qb2.ParameterCollector>` is contained by the :java:ref:`QueryBuilderBaseImpl<ch.tocco.nice2.persist.hibernate.query.QueryBuilderBaseImpl>`
+The :abbr:`ParameterCollector (ch.tocco.nice2.persist.impl.qb2.ParameterCollector)` is contained by the :abbr:`QueryBuilderBaseImpl (ch.tocco.nice2.persist.hibernate.query.QueryBuilderBaseImpl)`
 base class, because it is needed to create conditions.
 
 .. warning::
     It is important that only one parameter collector is used per query. Otherwise the parameter names are not unique and
-    the parameter values get overwritten. This means that all :java:ref:`Node<ch.tocco.nice2.conditionals.tree.Node>` instances
+    the parameter values get overwritten. This means that all :abbr:`Node (ch.tocco.nice2.conditionals.tree.Node)` instances
     passed to ``QueryBuilderBase#addCondition()`` must not have been already been processed by a parameter collector.
 
-Before the query is executed the parameters collected by the :java:ref:`ParameterCollector<ch.tocco.nice2.persist.impl.qb2.ParameterCollector>`
+Before the query is executed the parameters collected by the :abbr:`ParameterCollector (ch.tocco.nice2.persist.impl.qb2.ParameterCollector)`
 as well as parameters that are manually passed to ``AbstractCriteriaBuilder#addParameter#addParameter()`` are applied to the
-:java:extdoc:`Query<org.hibernate.query.Query>` instance (see ``AbstractCriteriaBuilder#applyParametersToQuery()``).
+:java-hibernate:`Query <org/hibernate/query/Query>` instance (see ``AbstractCriteriaBuilder#applyParametersToQuery()``).
 
 If the parameter value does not match the parameter type it is attempted to convert the value using ``TypeManager#convert()``.
-If a :java:extdoc:`Collection<java.util.Collection>` is used as a parameter value ``Query#setParameterList()`` is used which can be
+If a :java:`Collection <java/util/Collection>` is used as a parameter value ``Query#setParameterList()`` is used which can be
 substantially faster for large parameter lists.
 
 There are also global parameters that are applied to every query if a parameter with a certain name exists.
-These are provided by the :java:ref:`ParameterProvider<ch.tocco.nice2.persist.hibernate.query.ParameterProvider>` interface.
-An example would be the parameter ``currentUser`` (see :java:ref:`PrincipalNameFactory<ch.tocco.nice2.userbase.impl.ArgumentFactories.PrincipalNameFactory>`).
+These are provided by the :abbr:`ParameterProvider (ch.tocco.nice2.persist.hibernate.query.ParameterProvider)` interface.
+An example would be the parameter ``currentUser`` (see :abbr:`PrincipalNameFactory (ch.tocco.nice2.userbase.impl.ArgumentFactories.PrincipalNameFactory)`).
 
 Subqueries
 ~~~~~~~~~~
 
-The :java:ref:`AbstractCriteriaBuilder<ch.tocco.nice2.persist.hibernate.query.AbstractCriteriaBuilder>` also contains the
-only implementation of the :java:ref:`SubqueryFactory<ch.tocco.nice2.persist.hibernate.query.PredicateBuilder.SubqueryFactory>`
+The :abbr:`AbstractCriteriaBuilder (ch.tocco.nice2.persist.hibernate.query.AbstractCriteriaBuilder)` also contains the
+only implementation of the :abbr:`SubqueryFactory (ch.tocco.nice2.persist.hibernate.query.PredicateBuilder.SubqueryFactory)`
 which can be used to create subqueries.
 
 There are two different options:
@@ -132,20 +132,20 @@ There are two different options:
     * ``createUncorrelatedSubquery()`` can be used to create any other subquery that is not correlated to the main query. The selection and
       target entity can be freely chosen.
 
-Both methods return an instance of :java:ref:`SubqueryBuilderImpl<ch.tocco.nice2.persist.hibernate.query.SubqueryBuilderImpl>` which supports
+Both methods return an instance of :abbr:`SubqueryBuilderImpl (ch.tocco.nice2.persist.hibernate.query.SubqueryBuilderImpl)` which supports
 similar functionality as the standard query builder.
 
 ch.tocco.nice2.persist.hibernate.query.CriteriaQueryBuilderImpl
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The :java:ref:`CriteriaQueryBuilderImpl<ch.tocco.nice2.persist.hibernate.query.CriteriaQueryBuilderImpl>` is a base class for
+The :abbr:`CriteriaQueryBuilderImpl (ch.tocco.nice2.persist.hibernate.query.CriteriaQueryBuilderImpl)` is a base class for
 'standard' query builders that expect multiple result rows and adds support for offset, limit and ordering.
 
 Ordering
 ~~~~~~~~
-The ordering can be defined through ``CriteriaQueryBuilderImpl#addOrder()``. Both the JPA :java:extdoc:`Order<javax.persistence.criteria.Order>`
-(can be created by the :java:extdoc:`CriteriaBuilder<javax.persistence.criteria.CriteriaBuilder>`)
-and the :java:ref:`Ordering<ch.tocco.nice2.persist.query.Ordering>` class of the persist API are accepted.
+The ordering can be defined through ``CriteriaQueryBuilderImpl#addOrder()``. Both the JPA :java-javax:`Order <javax/persistence/criteria/Order>`
+(can be created by the :java-javax:`CriteriaBuilder <javax/persistence/criteria/CriteriaBuilder>`)
+and the :abbr:`Ordering (ch.tocco.nice2.persist.query.Ordering)` class of the persist API are accepted.
 
 There is a special ordering expression that can order the results by a given list of keys.
 This is created using ``OrderingUtils#orderByKeys()`` and results in a ``ORDER BY CASE WHEN ...`` clause.
@@ -157,20 +157,20 @@ This is created using ``OrderingUtils#orderByKeys()`` and results in a ``ORDER B
 
 Query Wrappers
 ~~~~~~~~~~~~~~
-The :java:ref:`CriteriaQueryBuilderImpl<ch.tocco.nice2.persist.hibernate.query.CriteriaQueryBuilderImpl>` defines that all
-subclasses must return an implementation of :java:ref:`CriteriaQueryWrapper<ch.tocco.nice2.persist.hibernate.query.CriteriaQueryWrapper>`
+The :abbr:`CriteriaQueryBuilderImpl (ch.tocco.nice2.persist.hibernate.query.CriteriaQueryBuilderImpl)` defines that all
+subclasses must return an implementation of :abbr:`CriteriaQueryWrapper (ch.tocco.nice2.persist.hibernate.query.CriteriaQueryWrapper)`
 from their ``build()`` method and provides a base implementation (``AbstractCriteriaQueryWrapper``).
 
 It also defines the ``QT`` type parameter of its superclass to ``Object[]``. That means that the hibernate queries always
 return ``Object[]`` instances. This is necessary because sometime we need to expand the user selection (see below).
 
-The :java:ref:`CriteriaQueryWrapper<ch.tocco.nice2.persist.hibernate.query.CriteriaQueryWrapper>` interface defines the
+The :abbr:`CriteriaQueryWrapper (ch.tocco.nice2.persist.hibernate.query.CriteriaQueryWrapper)` interface defines the
 following methods:
 
     * ``getResultList()`` returns a list of results
     * ``firstResult()`` returns the first result that was found
     * ``uniqueResult()`` returns exactly one result or null. If the query returns multiple rows, an exception will be thrown.
-      Optionally a :java:extdoc:`LockModeType<javax.persistence.LockModeType>` can be passed to this method, which allows
+      Optionally a :java-javax:`LockModeType <javax/persistence/LockModeType>` can be passed to this method, which allows
       pessimistic locking of an entity.
 
 ``firstResult()`` and  ``uniqueResult()`` will throw an exception if no result was found. However there are
@@ -181,17 +181,17 @@ following methods:
 .. note::
     Because a join in TQL is always a ``LEFT JOIN`` all standard queries need to be executed ``DISTINCT``
     to avoid duplicate results.
-    However some :java:extdoc:`LockModeType<javax.persistence.LockModeType>` cause a ``SELECT FOR UPDATE`` which does not support
+    However some :java-javax:`LockModeType <javax/persistence/LockModeType>` cause a ``SELECT FOR UPDATE`` which does not support
     distinct queries. In that case, distinct queries need to be manually disabled by calling ``distinct(false)``.
 
 AbstractCriteriaQueryWrapper
 ````````````````````````````
 
-The :java:ref:`AbstractCriteriaQueryWrapper<ch.tocco.nice2.persist.hibernate.query.CriteriaQueryBuilderImpl.AbstractCriteriaQueryWrapper>`
-is the base implementation of :java:ref:`CriteriaQueryWrapper<ch.tocco.nice2.persist.hibernate.query.CriteriaQueryWrapper>` and provides
+The :abbr:`AbstractCriteriaQueryWrapper (ch.tocco.nice2.persist.hibernate.query.CriteriaQueryBuilderImpl.AbstractCriteriaQueryWrapper)`
+is the base implementation of :abbr:`CriteriaQueryWrapper (ch.tocco.nice2.persist.hibernate.query.CriteriaQueryWrapper)` and provides
 the following functionality:
 
-It requires a transformation :java:extdoc:`Function<java.util.function.Function>` which converts a result row (which is always
+It requires a transformation :java:`Function <java/util/function/Function>` which converts a result row (which is always
 an ``Object[]``) into the desired target type (subclasses must override ``createMapperFunction()``).
 
 When ``getResultList()`` is called, the following steps are taken:
@@ -200,7 +200,7 @@ When ``getResultList()`` is called, the following steps are taken:
       In addition, the primary key is always added as the last sorting parameter (unless it already is part of the sorting clause).
       This is necessary to guarantee a consistent ordering when ``LIMIT`` or ``OFFSET`` is used (otherwise the order might be
       partially random if there are many rows with same value in the order column).
-    * The final :java:extdoc:`Selection<javax.persistence.criteria.Selection>` of the query is determined: The user defined selection
+    * The final :java-javax:`Selection <javax/persistence/criteria/Selection>` of the query is determined: The user defined selection
       is provided by the subclass (abstract method ``getSelection()``), however it might have to be expanded:
 
       According to the SQL Standard all columns that are part of the ``ORDER BY`` clause must also be part of the select clause
@@ -212,14 +212,14 @@ When ``getResultList()`` is called, the following steps are taken:
       the ``ORDER BY`` expression needs to be replaced with a literal reference to the selection (``ORDER BY 1`` for example),
       otherwise PostgreSQL does not recognize that both of these expressions are the same. Since by default all literals
       will be rendered as parameters we need to explicitly use ``CriteriaBuilderWrapper#inlineLiteral()`` that uses an
-      :java:ref:`InlineLiteralExpression<ch.tocco.nice2.persist.hibernate.InlineLiteralExpression>` which overrides the
-      default :java:extdoc:`LiteralHandlingMode<org.hibernate.query.criteria.LiteralHandlingMode>` to ``AUTO`` (we do
+      :abbr:`InlineLiteralExpression (ch.tocco.nice2.persist.hibernate.InlineLiteralExpression)` which overrides the
+      default :java-hibernate:`LiteralHandlingMode <org/hibernate/query/criteria/LiteralHandlingMode>` to ``AUTO`` (we do
       not use ``INLINE`` to make sure that strings are never inlined, as this would be an SQL injection risk).
 
       Due to a bug in hibernate an array selection of size 1 is not returned as array. As this breaks our code we
       add a dummy selection (the literal '1') if the the selection size is 1.
 
-    * The :java:extdoc:`CriteriaQuery<javax.persistence.criteria.CriteriaQuery>` is then converted into a :java:extdoc:`Query<org.hibernate.query.Query>` and
+    * The :java-javax:`CriteriaQuery <javax/persistence/criteria/CriteriaQuery>` is then converted into a :java-hibernate:`Query <org/hibernate/query/Query>` and
       selection, conditions, ordering and parameters are applied.
     * The query is then executed and the results returned after they have been processed by the transformation function (see above).
 
@@ -228,34 +228,34 @@ When ``getResultList()`` is called, the following steps are taken:
 ch.tocco.nice2.persist.hibernate.query.EntityQueryBuilderImpl
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The :java:ref:`EntityQueryBuilderImpl<ch.tocco.nice2.persist.hibernate.query.EntityQueryBuilderImpl>` is an implementation
-that queries for :java:ref:`Entity<ch.tocco.nice2.persist.entity.Entity>` instances.
+The :abbr:`EntityQueryBuilderImpl (ch.tocco.nice2.persist.hibernate.query.EntityQueryBuilderImpl)` is an implementation
+that queries for :abbr:`Entity (ch.tocco.nice2.persist.entity.Entity)` instances.
 
-It defines the :java:extdoc:`Root<javax.persistence.criteria.Root>` as the selection of the query and the mapping function
-simply casts the first element of the result array into an :java:ref:`Entity<ch.tocco.nice2.persist.entity.Entity>`.
+It defines the :java-javax:`Root <javax/persistence/criteria/Root>` as the selection of the query and the mapping function
+simply casts the first element of the result array into an :abbr:`Entity (ch.tocco.nice2.persist.entity.Entity)`.
 
 ch.tocco.nice2.persist.hibernate.query.AbstractPathQueryBuilder
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The :java:ref:`AbstractPathQueryBuilder<ch.tocco.nice2.persist.hibernate.query.AbstractPathQueryBuilder>` is a base class
-for query builders that use a :java:ref:`CustomSelection<ch.tocco.nice2.persist.hibernate.query.selection.CustomSelection>`.
+The :abbr:`AbstractPathQueryBuilder (ch.tocco.nice2.persist.hibernate.query.AbstractPathQueryBuilder)` is a base class
+for query builders that use a :abbr:`CustomSelection (ch.tocco.nice2.persist.hibernate.query.selection.CustomSelection)`.
 This means that they do not return entity instances, but only certain paths.
 
 It provides a method called ``clearSelection()`` that re-initializes the selection. However this method cannot remove joins that
 were created by the previous selection and is used internally only.
 
-This class also provides the :java:ref:`CriteriaQueryWrapper<ch.tocco.nice2.persist.hibernate.query.CriteriaQueryWrapper>` implementation
-for its subclasses: :java:ref:`CustomSelectionCriteriaQueryWrapper<ch.tocco.nice2.persist.hibernate.query.AbstractPathQueryBuilder.CustomSelectionCriteriaQueryWrapper>`.
+This class also provides the :abbr:`CriteriaQueryWrapper (ch.tocco.nice2.persist.hibernate.query.CriteriaQueryWrapper)` implementation
+for its subclasses: :abbr:`CustomSelectionCriteriaQueryWrapper (ch.tocco.nice2.persist.hibernate.query.AbstractPathQueryBuilder.CustomSelectionCriteriaQueryWrapper)`.
 ``getSelection()`` returns the selection created by ``CustomSelection#toJpaSelection()``.
 
 It provides a protected method ``mapResults()`` that initializes the result structure and processes the query results using ``CustomSelection#mapResults()``.
-This is necessary because the :java:ref:`CustomSelection<ch.tocco.nice2.persist.hibernate.query.selection.CustomSelection>`
+This is necessary because the :abbr:`CustomSelection (ch.tocco.nice2.persist.hibernate.query.selection.CustomSelection)`
 may add additional paths (for internal processing) and some paths need to evaluated in an additional query (to-many paths for example).
 
 ch.tocco.nice2.persist.hibernate.query.SinglePathQueryBuilderImpl
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The :java:ref:`SinglePathQueryBuilderImpl<ch.tocco.nice2.persist.hibernate.query.SinglePathQueryBuilderImpl>` can be used to
+The :abbr:`SinglePathQueryBuilderImpl (ch.tocco.nice2.persist.hibernate.query.SinglePathQueryBuilderImpl)` can be used to
 query for exactly one path of an entity. The constructor takes a ``Class<T>`` parameter which defines the return type
 of the query.
 
@@ -264,35 +264,35 @@ It is verified if the selected path matches the return type, otherwise an except
 
 An exception is also thrown if ``setPath(String)`` is never called.
 
-It returns a :java:ref:`CustomSelectionCriteriaQueryWrapper<ch.tocco.nice2.persist.hibernate.query.AbstractPathQueryBuilder.CustomSelectionCriteriaQueryWrapper>`
+It returns a :abbr:`CustomSelectionCriteriaQueryWrapper (ch.tocco.nice2.persist.hibernate.query.AbstractPathQueryBuilder.CustomSelectionCriteriaQueryWrapper)`
 from its ``build()`` method with a mapping function that returns the first element of the result array.
 
-It also provides a simple implementation of :java:ref:`ResultRowMapper<ch.tocco.nice2.persist.hibernate.query.mapper.ResultRowMapper>`.
+It also provides a simple implementation of :abbr:`ResultRowMapper (ch.tocco.nice2.persist.hibernate.query.mapper.ResultRowMapper)`.
 Because the result is always the selected path of type ``T`` the ``mapToOnePath()`` and ``mapToManyPath()`` methods can simply return
-the values provided by the given :java:ref:`ValueProvider<ch.tocco.nice2.persist.hibernate.query.mapper.ResultRowMapper.ValueProvider>`.
+the values provided by the given :abbr:`ValueProvider (ch.tocco.nice2.persist.hibernate.query.mapper.ResultRowMapper.ValueProvider)`.
 
-See :ref:`custom_selection` for more information about the :java:ref:`ResultRowMapper<ch.tocco.nice2.persist.hibernate.query.mapper.ResultRowMapper>`
+See :ref:`custom_selection` for more information about the :abbr:`ResultRowMapper (ch.tocco.nice2.persist.hibernate.query.mapper.ResultRowMapper)`
 class.
 
 ch.tocco.nice2.persist.hibernate.query.PathQueryBuilderImpl
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The :java:ref:`PathQueryBuilderImpl<ch.tocco.nice2.persist.hibernate.query.PathQueryBuilderImpl>` can be used to
+The :abbr:`PathQueryBuilderImpl (ch.tocco.nice2.persist.hibernate.query.PathQueryBuilderImpl)` can be used to
 query for multiple paths of an entity and always returns a container type like ``Object[]`` or ``Map``.
 
-The constructor of this class requires an instance of :java:ref:`ResultRowMapper<ch.tocco.nice2.persist.hibernate.query.mapper.ResultRowMapper>`
+The constructor of this class requires an instance of :abbr:`ResultRowMapper (ch.tocco.nice2.persist.hibernate.query.mapper.ResultRowMapper)`
 that supports the return type ``T``.
 
 There currently are two different implementations available:
 
-    * :java:ref:`ArrayResultRowMapper<ch.tocco.nice2.persist.hibernate.query.mapper.ArrayResultRowMapperFactory.ArrayResultRowMapper>` converts
+    * :abbr:`ArrayResultRowMapper (ch.tocco.nice2.persist.hibernate.query.mapper.ArrayResultRowMapperFactory.ArrayResultRowMapper)` converts
       query results into a flat structure using an ``Object[]``. The order in the array depends on the order the paths were given
       to ``addPathToSelection()``.
-    * :java:ref:`MapResultRowMapper<ch.tocco.nice2.persist.hibernate.query.mapper.MapResultRowMapperFactory.MapResultRowMapper>` converts each row
-      into a :java:extdoc:`Map<java.util.Map>`. This creates a nested structure and is useful to group fields by their relation paths.
+    * :abbr:`MapResultRowMapper (ch.tocco.nice2.persist.hibernate.query.mapper.MapResultRowMapperFactory.MapResultRowMapper)` converts each row
+      into a :java:`Map <java/util/Map>`. This creates a nested structure and is useful to group fields by their relation paths.
 
-The ``PersistenceService#createPathQueryBuilder()`` methods builds an instance of :java:ref:`ResultRowMapper<ch.tocco.nice2.persist.hibernate.query.mapper.ResultRowMapper>`
-using contributed :java:ref:`ResultRowMapperFactory<ch.tocco.nice2.persist.hibernate.query.mapper.ResultRowMapperFactory>` instances, based on the
+The ``PersistenceService#createPathQueryBuilder()`` methods builds an instance of :abbr:`ResultRowMapper (ch.tocco.nice2.persist.hibernate.query.mapper.ResultRowMapper)`
+using contributed :abbr:`ResultRowMapperFactory (ch.tocco.nice2.persist.hibernate.query.mapper.ResultRowMapperFactory)` instances, based on the
 requested result type.
 
 The method ``addPathToSelection()`` can be called multiple times to add paths to the selection.
@@ -301,10 +301,10 @@ At least one path needs to be added otherwise an exception will be thrown.
 ch.tocco.nice2.persist.hibernate.query.CriteriaCountQueryBuilder
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The :java:ref:`CriteriaCountQueryBuilder<ch.tocco.nice2.persist.hibernate.query.CriteriaCountQueryBuilder>`
-executes ``COUNT`` queries and always returns a :java:extdoc:`Long<java.lang.Long>`.
+The :abbr:`CriteriaCountQueryBuilder (ch.tocco.nice2.persist.hibernate.query.CriteriaCountQueryBuilder)`
+executes ``COUNT`` queries and always returns a :java:`Long <java/lang/Long>`.
 
-It inherits directly from :java:ref:`AbstractCriteriaBuilder<ch.tocco.nice2.persist.hibernate.query.AbstractCriteriaBuilder>`
+It inherits directly from :abbr:`AbstractCriteriaBuilder (ch.tocco.nice2.persist.hibernate.query.AbstractCriteriaBuilder)`
 because it does not return an ``Object[]`` and also returns a different object from its ``build()`` method.
 
 .. _custom_selection:
@@ -312,7 +312,7 @@ because it does not return an ``Object[]`` and also returns a different object f
 Custom Selection
 ----------------
 
-The :java:ref:`CustomSelection<ch.tocco.nice2.persist.hibernate.query.selection.CustomSelection>` is used by some query builders
+The :abbr:`CustomSelection (ch.tocco.nice2.persist.hibernate.query.selection.CustomSelection)` is used by some query builders
 that select only certain paths (not entire entities).
 
 It is not sufficient to simply add all requested paths to the JPA selection due to the following reasons:
@@ -323,7 +323,7 @@ It is not sufficient to simply add all requested paths to the JPA selection due 
     * Paths pointing to a to-many property would return multiple rows per target entity. Even if the data would be
       merged later, it would make ``LIMIT/OFFSET`` options useless.
 
-A custom selection contains a :java:ref:`SelectionRegistry<ch.tocco.nice2.persist.hibernate.query.selection.SelectionRegistry>`.
+A custom selection contains a :abbr:`SelectionRegistry (ch.tocco.nice2.persist.hibernate.query.selection.SelectionRegistry)`.
 The selection registry keeps track of all 'requested paths' (paths that should be included in the final ``Object[]``
 returned from the query builder) and all 'query paths' (paths that are included in the query).
 Not all 'requested paths' will generate a 'query path' (for example to-many paths are evaluated in a separate query) and
@@ -332,25 +332,25 @@ query builder.
 The selection registry maintains maps that keep track which query/requested path is at which position in the result arrays.
 It also makes sure that there are no duplicated 'query paths' (for example when the same internal path is required by
 multiple paths).
-All the query paths can be converted into a JPA :java:extdoc:`Selection<javax.persistence.criteria.Selection>` by the
+All the query paths can be converted into a JPA :java-javax:`Selection <javax/persistence/criteria/Selection>` by the
 method ``toSelection()``.
 
-The :java:ref:`CustomSelection<ch.tocco.nice2.persist.hibernate.query.selection.CustomSelection>` also contains multiple
-:java:ref:`SelectionPathHandler<ch.tocco.nice2.persist.hibernate.query.selection.SelectionPathHandler>`.
-A :java:ref:`SelectionPathHandler<ch.tocco.nice2.persist.hibernate.query.selection.SelectionPathHandler>` is responsible
+The :abbr:`CustomSelection (ch.tocco.nice2.persist.hibernate.query.selection.CustomSelection)` also contains multiple
+:abbr:`SelectionPathHandler (ch.tocco.nice2.persist.hibernate.query.selection.SelectionPathHandler)`.
+A :abbr:`SelectionPathHandler (ch.tocco.nice2.persist.hibernate.query.selection.SelectionPathHandler)` is responsible
 for handling a certain type of path.
 
-``SelectionPathHandler#processSelection()`` is called just before the JPA :java:extdoc:`Selection<javax.persistence.criteria.Selection>`
-is created. The :java:ref:`SelectionRegistry<ch.tocco.nice2.persist.hibernate.query.selection.SelectionRegistry>` is passed
+``SelectionPathHandler#processSelection()`` is called just before the JPA :java-javax:`Selection <javax/persistence/criteria/Selection>`
+is created. The :abbr:`SelectionRegistry (ch.tocco.nice2.persist.hibernate.query.selection.SelectionRegistry)` is passed
 as an argument and can be used to add all necessary query paths to the query.
 
 ``SelectionPathHandler#processResults()`` is called after the query has been executed. Both the list of results of the query
 and the target (that will be returned from the query builder) are passed as arguments. The task of the handler is to
-copy the query results into the target array. The :java:ref:`SelectionRegistry<ch.tocco.nice2.persist.hibernate.query.selection.SelectionRegistry>`
-contains the source and target indices of the paths. In addition an instance of :java:ref:`ResultRowMapper<ch.tocco.nice2.persist.hibernate.query.mapper.ResultRowMapper>`
+copy the query results into the target array. The :abbr:`SelectionRegistry (ch.tocco.nice2.persist.hibernate.query.selection.SelectionRegistry)`
+contains the source and target indices of the paths. In addition an instance of :abbr:`ResultRowMapper (ch.tocco.nice2.persist.hibernate.query.mapper.ResultRowMapper)`
 is passed to this method as well.
 
-The :java:ref:`ResultRowMapper<ch.tocco.nice2.persist.hibernate.query.mapper.ResultRowMapper>`
+The :abbr:`ResultRowMapper (ch.tocco.nice2.persist.hibernate.query.mapper.ResultRowMapper)`
 does the actual mapping to the final result structure and has the following methods:
 
     * ``createInstanceOfResultType()`` creates an instance of the result container (like ``Object[]``, ``Map``). May also
@@ -358,36 +358,36 @@ does the actual mapping to the final result structure and has the following meth
     * ``mapToOnePath()`` maps to-one paths to the result container. It has the following parameters:
 
         * ``paths`` all the paths that should be mapped
-        * ``queryResultProvider`` an instance of :java:ref:`ValueProvider<ch.tocco.nice2.persist.hibernate.query.mapper.ResultRowMapper.ValueProvider>`
+        * ``queryResultProvider`` an instance of :abbr:`ValueProvider (ch.tocco.nice2.persist.hibernate.query.mapper.ResultRowMapper.ValueProvider)`
           that allows to access the result of the current row for a given path
         * ``result`` an instance of the result container. The results should be mapped to this object.
         * ``rootSelectionRegistry`` can be used to access the index of a given path to be able to insert it in the correct
           position of the result container
 
     *   ``mapToManyPath()`` maps to-many paths to the result container. It has the same parameters as ``mapToOnePath()``, except
-        that it receives a list of :java:ref:`ValueProvider<ch.tocco.nice2.persist.hibernate.query.mapper.ResultRowMapper.ValueProvider>`
+        that it receives a list of :abbr:`ValueProvider (ch.tocco.nice2.persist.hibernate.query.mapper.ResultRowMapper.ValueProvider)`
 
-The :java:ref:`SelectionPathHandler<ch.tocco.nice2.persist.hibernate.query.selection.SelectionPathHandler>` are also
-responsible for calling the :java:ref:`QueryBuilderInterceptor<ch.tocco.nice2.persist.hibernate.query.QueryBuilderInterceptor>`
+The :abbr:`SelectionPathHandler (ch.tocco.nice2.persist.hibernate.query.selection.SelectionPathHandler)` are also
+responsible for calling the :abbr:`QueryBuilderInterceptor (ch.tocco.nice2.persist.hibernate.query.QueryBuilderInterceptor)`
 selection builder methods.
 
-    * The :java:ref:`ToOneSelectionPathHandler<ch.tocco.nice2.persist.hibernate.query.selection.ToOneSelectionPathHandler>`
+    * The :abbr:`ToOneSelectionPathHandler (ch.tocco.nice2.persist.hibernate.query.selection.ToOneSelectionPathHandler)`
       is responsible for all 'to-one' paths. It is relatively straight-forward: the paths can be included in the query
       and after the query execution the paths can simply mapped to the target array.
 
-    * The :java:ref:`ToManySelectionPathHandler<ch.tocco.nice2.persist.hibernate.query.selection.ToManySelectionPathHandler>`
+    * The :abbr:`ToManySelectionPathHandler (ch.tocco.nice2.persist.hibernate.query.selection.ToManySelectionPathHandler)`
       handles all 'to-many' paths. These paths cannot be selected directly in the query. For each base path a separate
       query is generated that retrieves the values of these paths for *all* rows. The rows are then mapped to the target array
       using the primary key of the root entity, that is selected by both queries.
 
     * There are special implementations for ``binary`` fields, because the ``_nice_binary`` table is not mapped by
-      hibernate at the moment and cannot be queried directly. They use the :java:ref:`BinaryDataAccessor<ch.tocco.nice2.persist.hibernate.binary.BinaryDataAccessor>`
-      to efficiently load :java:ref:`BinaryData<ch.tocco.nice2.persist.hibernate.binary.BinaryData>` instances, which are then merged
+      hibernate at the moment and cannot be queried directly. They use the :abbr:`BinaryDataAccessor (ch.tocco.nice2.persist.hibernate.binary.BinaryDataAccessor)`
+      to efficiently load :abbr:`BinaryData (ch.tocco.nice2.persist.hibernate.binary.BinaryData)` instances, which are then merged
       into the target array.
 
 Query Builder Interceptor
 -------------------------
-The :java:ref:`QueryBuilderInterceptor<ch.tocco.nice2.persist.hibernate.query.QueryBuilderInterceptor>` participates
+The :abbr:`QueryBuilderInterceptor (ch.tocco.nice2.persist.hibernate.query.QueryBuilderInterceptor)` participates
 in the query building process.
 
 ``buildConditionFor()``
@@ -398,11 +398,11 @@ This method is called for every query root and for every subquery and can add ad
     - ``BusinessUnitQueryBuilderInterceptor`` makes sure that only entities belonging to the current business unit are returned
     - ``SecureQueryInterceptor`` adds additional conditions based on the security policy
 
-The method takes an instance of :java:ref:`QueryBuilderType<ch.tocco.nice2.persist.hibernate.query.QueryBuilderInterceptor.QueryBuilderType>`
+The method takes an instance of :abbr:`QueryBuilderType (ch.tocco.nice2.persist.hibernate.query.QueryBuilderInterceptor.QueryBuilderType)`
 which signifies by what kind of query builder it is called. Currently ``READ`` and ``DELETE`` are supported. The
 ``SecureQueryInterceptor`` uses this information to apply the correct security conditions depending on the query type.
 
-The argument :java:ref:`QueryBuilderSituation<ch.tocco.nice2.persist.hibernate.query.QueryBuilderInterceptor.QueryBuilderSituation>`
+The argument :abbr:`QueryBuilderSituation (ch.tocco.nice2.persist.hibernate.query.QueryBuilderInterceptor.QueryBuilderSituation)`
 indicates whether the returned conditions will be applied to a (sub)query or a join.
 
 ``fieldUsedInQueryCondition()``
@@ -415,12 +415,12 @@ an exception when a field is used that is marked as ``privileged-only`` in the f
 ``createSelectionInterceptor()``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This method is only used when a :java:ref:`CustomSelection<ch.tocco.nice2.persist.hibernate.query.selection.CustomSelection>`
+This method is only used when a :abbr:`CustomSelection (ch.tocco.nice2.persist.hibernate.query.selection.CustomSelection)`
 is used. It is called once for each 'base path' (a path without field) of the query.
 So for example when the paths ``relUser.name``, ``relUser.lastname``, ``relAddress.address``, ``relAddress.city`` are selected,
 the method is called once for ``relUser`` and ``relAddress``.
 
-The method may return an :java:ref:`SelectionInterceptor<ch.tocco.nice2.persist.hibernate.query.QueryBuilderInterceptor.SelectionInterceptor>`,
+The method may return an :abbr:`SelectionInterceptor (ch.tocco.nice2.persist.hibernate.query.QueryBuilderInterceptor.SelectionInterceptor)`,
 which allows modification of the selection and inspection & replacement of the query results.
 
 SelectionInterceptor
@@ -438,7 +438,7 @@ and ``Row#setValueForPath()``.
 Interceptors for Joins
 ----------------------
 
-The :java:ref:`QueryBuilderInterceptor<ch.tocco.nice2.persist.hibernate.query.QueryBuilderInterceptor>` is also called for
+The :abbr:`QueryBuilderInterceptor (ch.tocco.nice2.persist.hibernate.query.QueryBuilderInterceptor)` is also called for
 joins that are used in conditions (in addition to subqueries and the root entity) to make sure
 that the conditions cannot be used to bypass ACL rules.
 
@@ -461,17 +461,17 @@ Therefore the condition needs to be combined only with the clause that contains 
     ``where value = 1 AND <interceptor-condition> OR value = 2 AND <interceptor-condition> ...`` versus
     ``where value IN (1,2,...) AND <interceptor-condition>``.
 
-To achieve this we use an extended :java:extdoc:`CriteriaBuilder<javax.persistence.criteria.CriteriaBuilder>` that
+To achieve this we use an extended :java-javax:`CriteriaBuilder <javax/persistence/criteria/CriteriaBuilder>` that
 intercepts the creation of all predicates and wraps them with the conditions from the interceptors if necessary
-(:java:ref:`CriteriaBuilderWrapper<ch.tocco.nice2.persist.hibernate.query.CriteriaBuilderWrapper>`).
+(:abbr:`CriteriaBuilderWrapper (ch.tocco.nice2.persist.hibernate.query.CriteriaBuilderWrapper)`).
 
 The wrapper overrides methods like ``equal()`` and ``notEqual()``:
 
     * The creation of the actual predicate is delegated to the 'real' criteria builder
     * All expressions that are passed to the criteria builder (see below) are then processed by
-      the interceptors and the resulting :java:ref:`Node<ch.tocco.nice2.conditionals.tree.Node>` instances
-      will be converted to :java:extdoc:`Predicate<javax.persistence.criteria.Predicate>` instances using
-      a derived :java:ref:`PredicateFactory<ch.tocco.nice2.persist.hibernate.PredicateFactory>`. The predicate
+      the interceptors and the resulting :abbr:`Node (ch.tocco.nice2.conditionals.tree.Node)` instances
+      will be converted to :java-javax:`Predicate <javax/persistence/criteria/Predicate>` instances using
+      a derived :abbr:`PredicateFactory (ch.tocco.nice2.persist.hibernate.PredicateFactory)`. The predicate
       factory needs to be derived to use the current join as the query root (as the conditions are based on this
       entity, not the query root) and to use the real criteria builder to avoid endless recursion.
     * The actual predicate is then combined with the interceptor predicates and an AND predicate is returned from the call
@@ -479,11 +479,11 @@ The wrapper overrides methods like ``equal()`` and ``notEqual()``:
 
 Conditions are collected from the following expressions:
 
-:java:extdoc:`Path<javax.persistence.criteria.Path>`
+:java-javax:`Path <javax/persistence/criteria/Path>`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-A path might for example look like ``relEntity.relEntity2.field``. The :java:extdoc:`Path<javax.persistence.criteria.Path>` instance always references the last
-path element. If it is an instance of :java:extdoc:`From<javax.persistence.criteria.From>`, the last path element is
+A path might for example look like ``relEntity.relEntity2.field``. The :java-javax:`Path <javax/persistence/criteria/Path>` instance always references the last
+path element. If it is an instance of :java-javax:`From <javax/persistence/criteria/From>`, the last path element is
 a relation, otherwise it is a field.
 
 For the example path ``relUser.relAddress.city`` the conditions of the following interceptor calls
@@ -495,13 +495,13 @@ are collected:
     * ``buildConditionFor("User")``
     * ``fieldUsedInQueryCondition(ROOT, "relUser")``
 
-:java:extdoc:`ParameterizedFunctionExpression<org.hibernate.query.criteria.internal.expression.function.ParameterizedFunctionExpression>`
+:java-hibernate:`ParameterizedFunctionExpression <org/hibernate/query/criteria/internal/expression/function/ParameterizedFunctionExpression>`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-All parameter expressions of the function call are recursively evaluated (see above how :java:extdoc:`Path<javax.persistence.criteria.Path>`
+All parameter expressions of the function call are recursively evaluated (see above how :java-javax:`Path <javax/persistence/criteria/Path>`
 expression are evaluated).
 
-:java:extdoc:`Subquery<javax.persistence.criteria.Subquery>`
+:java-javax:`Subquery <javax/persistence/criteria/Subquery>`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A (correlated) subquery might be created for example from the following condition ``exists(relUser.relAddress.relStatus where ... )``.
@@ -509,7 +509,7 @@ A (correlated) subquery might be created for example from the following conditio
 In this example the ``relStatus`` join is the 'root' of the subquery: conditions of the ``Status`` entity do not need to be added to the join,
 they will already be added to the subquery. However it is necessary to check the field of that join (``Address#relStatus``).
 
-The ``relAddress`` join is the 'correlated' join. Conditions up to this join will be collected (see above how :java:extdoc:`Path<javax.persistence.criteria.Path>`
+The ``relAddress`` join is the 'correlated' join. Conditions up to this join will be collected (see above how :java-javax:`Path <javax/persistence/criteria/Path>`
 expression are evaluated).
 
 So for the above example the following interceptor calls are made:
@@ -525,7 +525,7 @@ Joins and fields in the ORDER BY clause
 
 It is also necessary to secure the ``ORDER BY`` clauses, it should not be possible to order by a field or relation
 that is not accessible.
-For that purpose the :java:ref:`CriteriaBuilderWrapper<ch.tocco.nice2.persist.hibernate.query.CriteriaBuilderWrapper>`
+For that purpose the :abbr:`CriteriaBuilderWrapper (ch.tocco.nice2.persist.hibernate.query.CriteriaBuilderWrapper)`
 also overrides the ``asc`` and ``desc`` methods and returns a modified order by clause that uses a ``SELECT CASE ... WHEN ...`` expression.
 
 Conditions are collected for the ``ORDER BY`` expression in the same way as described for conditions above.
@@ -536,37 +536,37 @@ rows where the ``ORDER BY`` clause is not accessible will be ordered like if the
 
 Custom JDBC Functions
 ---------------------
-Custom query functions can be implemented using the :java:ref:`JdbcFunction<ch.tocco.nice2.persist.hibernate.query.JdbcFunction>` interface.
-The contributions are registered with the :java:extdoc:`SessionFactoryBuilder<org.hibernate.boot.SessionFactoryBuilder>` by the
-:java:ref:`HibernateCoreBootstrapContribution<ch.tocco.nice2.persist.hibernate.bootstrap.HibernateCoreBootstrapContribution>`.
+Custom query functions can be implemented using the :abbr:`JdbcFunction (ch.tocco.nice2.persist.hibernate.query.JdbcFunction)` interface.
+The contributions are registered with the :java-hibernate:`SessionFactoryBuilder <org/hibernate/boot/SessionFactoryBuilder>` by the
+:abbr:`HibernateCoreBootstrapContribution (ch.tocco.nice2.persist.hibernate.bootstrap.HibernateCoreBootstrapContribution)`.
 
-In addition to the contributed functions, the :java:ref:`GlobSqlFunction<ch.tocco.nice2.persist.hibernate.dialect.GlobSqlFunction>`
+In addition to the contributed functions, the :abbr:`GlobSqlFunction (ch.tocco.nice2.persist.hibernate.dialect.GlobSqlFunction)`
 is registered as well. It implements the ``glob`` function, which is internally used when the ``Operator#LIKE`` is specified.
 It uses ``LIKE`` internally but is also replacing ``*`` with ``%`` and ``?`` with ``_`` so that both placeholders are supported.
 
-Each function must provide a :java:extdoc:`SQLFunction<org.hibernate.dialect.function.SQLFunction>` which contains the SQL template.
-Typically the :java:extdoc:`SQLFunctionTemplate<org.hibernate.dialect.function.SQLFunctionTemplate>` can be used for this.
-An instance of :java:ref:`SqlWriter<ch.tocco.nice2.persist.query.SqlWriter>` is provided to facilitate writing the SQL query. The
-sql writer is obtained from ``Context#createSqlWriter()`` and is automatically configured based on the current :java:extdoc:`Dialect<org.hibernate.dialect.Dialect>`.
+Each function must provide a :java-hibernate:`SQLFunction <org/hibernate/dialect/function/SQLFunction>` which contains the SQL template.
+Typically the :java-hibernate:`SQLFunctionTemplate <org/hibernate/dialect/function/SQLFunctionTemplate>` can be used for this.
+An instance of :abbr:`SqlWriter (ch.tocco.nice2.persist.query.SqlWriter)` is provided to facilitate writing the SQL query. The
+sql writer is obtained from ``Context#createSqlWriter()`` and is automatically configured based on the current :java-hibernate:`Dialect <org/hibernate/dialect/Dialect>`.
 
-The abstract base class :java:ref:`AbstractJdbcFunction<ch.tocco.nice2.persist.hibernate.query.AbstractJdbcFunction>` provides support
+The abstract base class :abbr:`AbstractJdbcFunction (ch.tocco.nice2.persist.hibernate.query.AbstractJdbcFunction)` provides support
 to create the sql function templates:
 
-    * Find the correct hibernate :java:extdoc:`Type<org.hibernate.type.Type>` based on the nice :java:ref:`Type<ch.tocco.nice2.types.Type>`
+    * Find the correct hibernate :java-hibernate:`Type <org/hibernate/type/Type>` based on the nice :abbr:`Type (ch.tocco.nice2.types.Type)`
     * The ``writeArgument()`` method can be used to write a parameter placeholder into the sql string
 
 .. warning::
 
-    The arguments of the :java:ref:`Condition<ch.tocco.nice2.persist.qb2.Condition>` are passed to the criteria builder in the same order.
+    The arguments of the :abbr:`Condition (ch.tocco.nice2.persist.qb2.Condition)` are passed to the criteria builder in the same order.
     If the order of arguments is different in the sql template or a parameter is used multiple times, the ``argumentOrder()`` method
-    needs to be overwritten by the :java:ref:`JdbcFunction<ch.tocco.nice2.persist.hibernate.query.JdbcFunction>`. The arguments
-    are then reordered and/or duplicated by the :java:ref:`FuncallArgumentProcessor<ch.tocco.nice2.persist.hibernate.pojo.CriteriaQueryCompiler.FuncallArgumentProcessor>`
+    needs to be overwritten by the :abbr:`JdbcFunction (ch.tocco.nice2.persist.hibernate.query.JdbcFunction)`. The arguments
+    are then reordered and/or duplicated by the :abbr:`FuncallArgumentProcessor (ch.tocco.nice2.persist.hibernate.pojo.CriteriaQueryCompiler.FuncallArgumentProcessor)`
     before the query is processed.
 
 .. note::
-    The :java:ref:`JdbcFunction<ch.tocco.nice2.persist.hibernate.query.JdbcFunction>` operates directly on the SQL level
+    The :abbr:`JdbcFunction (ch.tocco.nice2.persist.hibernate.query.JdbcFunction)` operates directly on the SQL level
     and can be used to access database specific functions.
-    An example is the :java:ref:`BirthdayQueryFunction<ch.tocco.nice2.persist.backend.jdbc.impl.functions.BirthdayQueryFunction>`
+    An example is the :abbr:`BirthdayQueryFunction (ch.tocco.nice2.persist.backend.jdbc.impl.functions.BirthdayQueryFunction)`
     that uses the ``extract`` PostgreSQL function.
 
 .. note::
@@ -576,24 +576,24 @@ to create the sql function templates:
 
 Query Functions
 ---------------
-A :java:ref:`QueryFunction<ch.tocco.nice2.persist.spi.query.ql.QueryFunction>` can be used to implement a custom function that
+A :abbr:`QueryFunction (ch.tocco.nice2.persist.spi.query.ql.QueryFunction)` can be used to implement a custom function that
 can be used in the query language.
-The query functions are applied by the :java:ref:`ConditionFactory<ch.tocco.nice2.persist.query.ConditionFactory>` when
-the :java:ref:`Node<ch.tocco.nice2.conditionals.tree.Node>` tree is processed and can manipulate its nodes.
+The query functions are applied by the :abbr:`ConditionFactory (ch.tocco.nice2.persist.query.ConditionFactory)` when
+the :abbr:`Node (ch.tocco.nice2.conditionals.tree.Node)` tree is processed and can manipulate its nodes.
 
 .. note::
-    An example would be the :java:ref:`FulltextSearchFunction<ch.tocco.nice2.enterprisesearch.impl.queryfunction.FulltextSearchFunction>`:
+    An example would be the :abbr:`FulltextSearchFunction (ch.tocco.nice2.enterprisesearch.impl.queryfunction.FulltextSearchFunction)`:
     It executes the fulltext search when the query is compiled and replaces the query function node with an ``IN`` condition
     that includes the primary keys of the results of the search.
 
 Query Compiler
 --------------
-The :java:ref:`CriteriaQueryCompiler<ch.tocco.nice2.persist.hibernate.pojo.CriteriaQueryCompiler>` is responsible for creating a
-:java:ref:`Query<ch.tocco.nice2.persist.query.Query>` instance based on a :java:ref:`Node<ch.tocco.nice2.conditionals.tree.Node>`.
+The :abbr:`CriteriaQueryCompiler (ch.tocco.nice2.persist.hibernate.pojo.CriteriaQueryCompiler)` is responsible for creating a
+:abbr:`Query (ch.tocco.nice2.persist.query.Query)` instance based on a :abbr:`Node (ch.tocco.nice2.conditionals.tree.Node)`.
 
-The :java:ref:`QueryVisitor<ch.tocco.nice2.persist.hibernate.pojo.CriteriaQueryCompiler.QueryVisitor>` visits the node tree
+The :abbr:`QueryVisitor (ch.tocco.nice2.persist.hibernate.pojo.CriteriaQueryCompiler.QueryVisitor)` visits the node tree
 and collects the entity model, condition and ordering data, which in turn will be
-wrapped in a :java:ref:`HibernateQueryAdapter<ch.tocco.nice2.persist.hibernate.pojo.HibernateQueryAdapter>` that is returned
+wrapped in a :abbr:`HibernateQueryAdapter (ch.tocco.nice2.persist.hibernate.pojo.HibernateQueryAdapter)` that is returned
 to the user.
 
 QueryVisitor
@@ -604,49 +604,49 @@ The query visitor handles the following funcall nodes:
     - ``Keywords.ORDER``: Each child node represents an order path and direction
     - ``Keywords.WHERE``: The condition of the query.
 
-The condition (the WHERE part of the query) is processed by the :java:ref:`ConditionFactory<ch.tocco.nice2.persist.query.ConditionFactory>`
+The condition (the WHERE part of the query) is processed by the :abbr:`ConditionFactory (ch.tocco.nice2.persist.query.ConditionFactory)`
 before it is added to the conditions list.
 The condition factory applies the following visitors:
 
-    - ``TypeSettingVisitor``: Sets the :java:ref:`Type<ch.tocco.nice2.types.Type>` of a field to the corresponding path node
-    - ``QueryFunctionCompiler``: Applies all :java:ref:`QueryFunction<ch.tocco.nice2.persist.spi.query.ql.QueryFunction>` to the conditions
+    - ``TypeSettingVisitor``: Sets the :abbr:`Type (ch.tocco.nice2.types.Type)` of a field to the corresponding path node
+    - ``QueryFunctionCompiler``: Applies all :abbr:`QueryFunction (ch.tocco.nice2.persist.spi.query.ql.QueryFunction)` to the conditions
 
 Predicate Factory
 -----------------
-The :java:ref:`PredicateFactory<ch.tocco.nice2.persist.hibernate.PredicateFactory>` converts :java:ref:`Node<ch.tocco.nice2.conditionals.tree.Node>` instances
-representing conditions into a :java:extdoc:`Predicate<javax.persistence.criteria.Predicate>`.
-These conditions are created by the :java:ref:`QueryBuilderFactory<ch.tocco.nice2.persist.qb2.QueryBuilderFactory>`
+The :abbr:`PredicateFactory (ch.tocco.nice2.persist.hibernate.PredicateFactory)` converts :abbr:`Node (ch.tocco.nice2.conditionals.tree.Node)` instances
+representing conditions into a :java-javax:`Predicate <javax/persistence/criteria/Predicate>`.
+These conditions are created by the :abbr:`QueryBuilderFactory (ch.tocco.nice2.persist.qb2.QueryBuilderFactory)`
 as well as the ACL parser.
 
-The node tree is parsed using different :java:ref:`NodeVisitor<ch.tocco.nice2.conditionals.tree.processing.NodeVisitor>`
-implementations, that all extend from :java:ref:`AbstractNodeVisitor<ch.tocco.nice2.persist.hibernate.PredicateFactory.AbstractNodeVisitor>`.
+The node tree is parsed using different :abbr:`NodeVisitor (ch.tocco.nice2.conditionals.tree.processing.NodeVisitor)`
+implementations, that all extend from :abbr:`AbstractNodeVisitor (ch.tocco.nice2.persist.hibernate.PredicateFactory.AbstractNodeVisitor)`.
 
 AbstractNodeVisitor
 ^^^^^^^^^^^^^^^^^^^
 This is the base class that all visitor implementations use. It defines an abstract method (``getPredicate()``) which
-should return a :java:extdoc:`Predicate<javax.persistence.criteria.Predicate>` instance for the current node.
-For example the :java:ref:`LogicalNodeVisitor<ch.tocco.nice2.persist.hibernate.PredicateFactory.LogicalNodeVisitor>` converts
-an :java:ref:`AndNode<ch.tocco.nice2.conditionals.tree.AndNode>`, :java:ref:`OrNode<ch.tocco.nice2.conditionals.tree.OrNode>` or
-:java:ref:`NotNode<ch.tocco.nice2.conditionals.tree.NotNode>` into a :java:extdoc:`CompoundPredicate<org.hibernate.query.criteria.internal.predicate.CompoundPredicate>`.
+should return a :java-javax:`Predicate <javax/persistence/criteria/Predicate>` instance for the current node.
+For example the :abbr:`LogicalNodeVisitor (ch.tocco.nice2.persist.hibernate.PredicateFactory.LogicalNodeVisitor)` converts
+an :abbr:`AndNode (ch.tocco.nice2.conditionals.tree.AndNode)`, :abbr:`OrNode (ch.tocco.nice2.conditionals.tree.OrNode)` or
+:abbr:`NotNode (ch.tocco.nice2.conditionals.tree.NotNode)` into a :java-hibernate:`CompoundPredicate <org/hibernate/query/criteria/internal/predicate/CompoundPredicate>`.
 
 Additionally the base class provides helper methods to handle child nodes (``handle[...]Node()``).
 These helper methods create a new visitor for the given node and pass it to ``processVisitor()``, which processes the node
 with the new visitor. It also calls ``Cursor#next()`` to make sure that nested calls are only handled by the newly created visitor.
 Each child node is processed in isolation by its own visitor instance and its results are then aggregated by the parent visitor.
 
-A :java:ref:`FuncallNode<ch.tocco.nice2.conditionals.tree.FuncallNode>` may be a placeholder for different types of nodes:
+A :abbr:`FuncallNode (ch.tocco.nice2.conditionals.tree.FuncallNode)` may be a placeholder for different types of nodes:
 
     - ``EXISTS`` subquery
     - ``IN`` condition
     - ``COUNT`` subquery
-    - a :java:ref:`JdbcFunction<ch.tocco.nice2.persist.hibernate.query.JdbcFunction>` call
+    - a :abbr:`JdbcFunction (ch.tocco.nice2.persist.hibernate.query.JdbcFunction)` call
 
 AbstractJoiningVisitor
 ^^^^^^^^^^^^^^^^^^^^^^
-An abstract base class that handles a :java:ref:`PathNode<ch.tocco.nice2.conditionals.tree.PathNode>` and converts
-the path into a :java:extdoc:`Path<javax.persistence.criteria.Path>` performing joins if necessary.
+An abstract base class that handles a :abbr:`PathNode (ch.tocco.nice2.conditionals.tree.PathNode)` and converts
+the path into a :java-javax:`Path <javax/persistence/criteria/Path>` performing joins if necessary.
 
-The actual work is done in :java:ref:`QueryBuilderJoinHelper<ch.tocco.nice2.persist.hibernate.QueryBuilderJoinHelper>`:
+The actual work is done in :abbr:`QueryBuilderJoinHelper (ch.tocco.nice2.persist.hibernate.QueryBuilderJoinHelper)`:
 
     - Iteration over all path parts (``relUser.relAddress.value`` would be three different parts)
     - If the part is an association a join to the target entity is performed
@@ -655,8 +655,8 @@ The actual work is done in :java:ref:`QueryBuilderJoinHelper<ch.tocco.nice2.pers
 If the path points to a primary key that is referenced in a many to one association, the foreign key field is returned
 instead of performing an unnecessary join (which results in ``address.fk_user = ?`` instead of ``INNER JOIN user ON user.pk = address.fk_user WHERE user.pk = ?``
 for performance reasons.
-This shortcut can only be used when the :java:ref:`QueryBuilderInterceptors<ch.tocco.nice2.persist.hibernate.query.QueryBuilderInterceptor>`
-do not need to add any conditions to that join. This is checked through the :java:ref:`JoinInfo<ch.tocco.nice2.persist.hibernate.JoinInfo>`
+This shortcut can only be used when the :abbr:`QueryBuilderInterceptors (ch.tocco.nice2.persist.hibernate.query.QueryBuilderInterceptor)`
+do not need to add any conditions to that join. This is checked through the :abbr:`JoinInfo (ch.tocco.nice2.persist.hibernate.JoinInfo)`
 class which internally uses the ``CriteriaBuilderWrapper#hasQueryRestrictions()`` method.
 
 When a join is created it corresponds to an actual JOIN in the SQL. Therefore it should be tried to reuse the join instances
@@ -664,26 +664,26 @@ if the same entity is going to be joined multiple times.
 
 RootNodeVisitor
 ^^^^^^^^^^^^^^^
-The :java:ref:`RootNodeVisitor<ch.tocco.nice2.persist.hibernate.PredicateFactory.RootNodeVisitor>` is the entry point which handles the
+The :abbr:`RootNodeVisitor (ch.tocco.nice2.persist.hibernate.PredicateFactory.RootNodeVisitor)` is the entry point which handles the
 root node. It simply delegates to the visitor that can handle the root node and returns the predicate of that visitor.
 
 LogicalNodeVisitor
 ^^^^^^^^^^^^^^^^^^
-The :java:ref:`LogicalNodeVisitor<ch.tocco.nice2.persist.hibernate.PredicateFactory.LogicalNodeVisitor>` is responsible for
-handling :java:ref:`AndNode<ch.tocco.nice2.conditionals.tree.AndNode>`, :java:ref:`OrNode<ch.tocco.nice2.conditionals.tree.OrNode>`
-and :java:ref:`NotNode<ch.tocco.nice2.conditionals.tree.NotNode>`.
+The :abbr:`LogicalNodeVisitor (ch.tocco.nice2.persist.hibernate.PredicateFactory.LogicalNodeVisitor)` is responsible for
+handling :abbr:`AndNode (ch.tocco.nice2.conditionals.tree.AndNode)`, :abbr:`OrNode (ch.tocco.nice2.conditionals.tree.OrNode)`
+and :abbr:`NotNode (ch.tocco.nice2.conditionals.tree.NotNode)`.
 
 This visitor collects all predicates of its child nodes (including other logical nodes) and nests them into an ``And``, ``Or`` or ``Not`` predicate.
 
 ExistsNodeVisitor
 ^^^^^^^^^^^^^^^^^
-The :java:ref:`ExistsNodeVisitor<ch.tocco.nice2.persist.hibernate.PredicateFactory.ExistsNodeVisitor>` handles
-a :java:ref:`FuncallNode<ch.tocco.nice2.conditionals.tree.FuncallNode>` with the ``EXISTS`` keyword.
+The :abbr:`ExistsNodeVisitor (ch.tocco.nice2.persist.hibernate.PredicateFactory.ExistsNodeVisitor)` handles
+a :abbr:`FuncallNode (ch.tocco.nice2.conditionals.tree.FuncallNode)` with the ``EXISTS`` keyword.
 These nodes represent an ``EXISTS`` subquery.
 
-The first child node is always a :java:ref:`PathNode<ch.tocco.nice2.conditionals.tree.PathNode>` that references the
+The first child node is always a :abbr:`PathNode (ch.tocco.nice2.conditionals.tree.PathNode)` that references the
 relation path which is queried by the subquery. Thus the ``visitPath()`` method first creates an instance of
-:java:extdoc:`Subquery<javax.persistence.criteria.Subquery>` through the :java:ref:`SubqueryFactory<ch.tocco.nice2.persist.hibernate.query.PredicateBuilder.SubqueryFactory>`.
+:java-javax:`Subquery <javax/persistence/criteria/Subquery>` through the :abbr:`SubqueryFactory (ch.tocco.nice2.persist.hibernate.query.PredicateBuilder.SubqueryFactory)`.
 
 The path node might contain multiple relation paths which leads to nested ``EXISTS`` subqueries.
 All exists predicates are collected on a stack until the path is parsed completely. The (optional)
@@ -693,33 +693,33 @@ The last element removed from the stack is returned from the visitor.
 
 InNodeVisitor
 ^^^^^^^^^^^^^
-The :java:ref:`InNodeVisitor<ch.tocco.nice2.persist.hibernate.PredicateFactory.InNodeVisitor>` is used for handling
+The :abbr:`InNodeVisitor (ch.tocco.nice2.persist.hibernate.PredicateFactory.InNodeVisitor)` is used for handling
 ``IN`` clauses.
 
 The values of the ``IN`` clause can either be specified as literals or parameters. The parameter names or literal values
-are collected, converted to :java:extdoc:`Expression<javax.persistence.criteria.Expression>` and then passed as parameters
-to an :java:extdoc:`InPredicate<org.hibernate.query.criteria.internal.predicate.InPredicate>`.
+are collected, converted to :java-javax:`Expression <javax/persistence/criteria/Expression>` and then passed as parameters
+to an :java-hibernate:`InPredicate <org/hibernate/query/criteria/internal/predicate/InPredicate>`.
 
 IsTrueNodeVisitor
 ^^^^^^^^^^^^^^^^^
-The :java:ref:`IsTrueNodeVisitor<ch.tocco.nice2.persist.hibernate.PredicateFactory.IsTrueNodeVisitor>` creates a boolean
-:java:extdoc:`Expression<javax.persistence.criteria.Expression>`.
-Either based on a :java:extdoc:`Path<javax.persistence.criteria.Path>` that points to a boolean or a literal expression.
+The :abbr:`IsTrueNodeVisitor (ch.tocco.nice2.persist.hibernate.PredicateFactory.IsTrueNodeVisitor)` creates a boolean
+:java-javax:`Expression <javax/persistence/criteria/Expression>`.
+Either based on a :java-javax:`Path <javax/persistence/criteria/Path>` that points to a boolean or a literal expression.
 The latter may be used by the security framework to deny any access (``AND false``).
 
 JpaIntegrationNodeVisitor
 ^^^^^^^^^^^^^^^^^^^^^^^^^
-The :java:ref:`JpaIntegrationNode<ch.tocco.nice2.persist.hibernate.query.JpaIntegrationNode>` contains a
-:java:ref:`PredicateBuilder<ch.tocco.nice2.persist.hibernate.query.PredicateBuilder>` which allows to create a
+The :abbr:`JpaIntegrationNode (ch.tocco.nice2.persist.hibernate.query.JpaIntegrationNode)` contains a
+:abbr:`PredicateBuilder (ch.tocco.nice2.persist.hibernate.query.PredicateBuilder)` which allows to create a
 condition using the new query builder features (for example uncorrelated subqueries).
 
 This makes it possible to integrate the new features with the old query builder (this was primarily created for the
-:java:ref:`PermissionMatrixEvaluationService<ch.tocco.nice2.dms.security.policyprocessor.PermissionMatrixEvaluationService>`).
+:abbr:`PermissionMatrixEvaluationService (ch.tocco.nice2.dms.security.policyprocessor.PermissionMatrixEvaluationService)`).
 
 EquationNodeHandler
 ^^^^^^^^^^^^^^^^^^^
-The :java:ref:`EquationNodeHandler<ch.tocco.nice2.persist.hibernate.EquationNodeHandler>` converts an
-:java:ref:`EquationNode<ch.tocco.nice2.conditionals.tree.EquationNode>` into a :java:extdoc:`Predicate<javax.persistence.criteria.Predicate>`.
+The :abbr:`EquationNodeHandler (ch.tocco.nice2.persist.hibernate.EquationNodeHandler)` converts an
+:abbr:`EquationNode (ch.tocco.nice2.conditionals.tree.EquationNode)` into a :java-javax:`Predicate <javax/persistence/criteria/Predicate>`.
 An equation node consists of two nodes and an operator that defines how the two nodes can be compared.
 
 Currently the following nodes are supported:
@@ -733,25 +733,25 @@ Currently the following nodes are supported:
 Obviously both nodes need to be of the same type, otherwise hibernate will throw an exception.
 Since both the ``ParameterNode`` and the ``LiteralNode`` can be converted to a different type (if a suitable converter
 exists), the 'other side' of the equation is evaluated first and then it is attempted to convert the literal or parameter
-using the :java:ref:`TypeManager<ch.tocco.nice2.types.TypeManager>` to the type of the 'other side' (if necessary).
+using the :abbr:`TypeManager (ch.tocco.nice2.types.TypeManager)` to the type of the 'other side' (if necessary).
 
 The ``LIKE`` operator is handled specially as it is not translated into a SQL ``LIKE`` but mapped to our custom ``glob``
-:java:extdoc:`SQLFunction<org.hibernate.dialect.function.SQLFunction>` (:java:ref:`GlobSqlFunction<ch.tocco.nice2.persist.hibernate.dialect.GlobSqlFunction>`).
+:java-hibernate:`SQLFunction <org/hibernate/dialect/function/SQLFunction>` (:abbr:`GlobSqlFunction (ch.tocco.nice2.persist.hibernate.dialect.GlobSqlFunction)`).
 Both sides of the equation are
 converted to lower case to simulate ``ILIKE`` behaviour.
 
 Localized fields
 ^^^^^^^^^^^^^^^^
 If a localized field is part of a query it needs to be resolved for the current locale before the query is parsed.
-This is achieved by the :java:ref:`EntityInterceptorVisitor<ch.tocco.nice2.persist.hibernate.pojo.EntityInterceptorVisitor>`
+This is achieved by the :abbr:`EntityInterceptorVisitor (ch.tocco.nice2.persist.hibernate.pojo.EntityInterceptorVisitor)`
 which is executed before the query is parsed by the predicate factory.
 
-All path nodes are processed by the :java:ref:`FieldResolver<ch.tocco.nice2.persist.hibernate.interceptor.FieldResolver>`
+All path nodes are processed by the :abbr:`FieldResolver (ch.tocco.nice2.persist.hibernate.interceptor.FieldResolver)`
 and all virtual fields are replaced.
 
 Delete query builder
 --------------------
-The :java:ref:`CriteriaDeleteBuilderImpl<ch.tocco.nice2.persist.hibernate.query.CriteriaDeleteBuilderImpl>` is a special query builder
+The :abbr:`CriteriaDeleteBuilderImpl (ch.tocco.nice2.persist.hibernate.query.CriteriaDeleteBuilderImpl)` is a special query builder
 implementation that can be used to delete multiple entities by query without the need to load every single entity.
 
 The query selects the primary keys of all entities that may be deleted (the correct security conditions are added by the
@@ -762,35 +762,35 @@ to avoid loading the entire entity unless it is absolutely necessary (for exampl
 Note that ``Entity#markDeleted()`` is used. This is an internal method that can be invoked without initializing the proxy
 (as opposed to ``delete()``) and causes ``getState()`` to correctly return ``PHANTOM``.
 
-After the invocation of the listeners the proxy instances are scheduled for deletion with the :java:ref:`EntityTransactionContext<ch.tocco.nice2.persist.hibernate.cascade.EntityTransactionContext>`.
+After the invocation of the listeners the proxy instances are scheduled for deletion with the :abbr:`EntityTransactionContext (ch.tocco.nice2.persist.hibernate.cascade.EntityTransactionContext)`.
 Note that the ``addDeletedEntityBatch()`` method is used that deletes the entire batch with one delete statement (as opposed to
 the normal behaviour which fires a delete statement for every deleted entity).
 
 QueryDefinition / QueryConfigurator
 -----------------------------------
 
-The :java:ref:`QueryDefinition<ch.tocco.nice2.persist.query.QueryDefinition>` contains all necessary information
-to build a query. It is used as a bridge between the legacy :java:ref:`Query<ch.tocco.nice2.persist.query.Query>`
+The :abbr:`QueryDefinition (ch.tocco.nice2.persist.query.QueryDefinition)` contains all necessary information
+to build a query. It is used as a bridge between the legacy :abbr:`Query (ch.tocco.nice2.persist.query.Query)`
 and the new query builders.
 
 An instance can be obtained from the method ``Query#toQueryDefinition()`` which can then be converted to a
-:java:ref:`QueryConfigurator<ch.tocco.nice2.persist.hibernate.query.builder.QueryConfigurator>` which can be
+:abbr:`QueryConfigurator (ch.tocco.nice2.persist.hibernate.query.builder.QueryConfigurator)` which can be
 applied to the new query builder using ``CriteriaQueryBuilder#applyConfiguration()``.
 
-This was primarily developed to be able to combine the :java:ref:`EntityExplorerActionSelectionService<ch.tocco.nice2.netui.actions.entityoperation.EntityExplorerActionSelectionService>`
+This was primarily developed to be able to combine the :abbr:`EntityExplorerActionSelectionService (ch.tocco.nice2.netui.actions.entityoperation.EntityExplorerActionSelectionService)`
 with the new query builders.
 
 Query hints
 -----------
 
-When a query builder instance is created using the :java:ref:`PersistenceService<ch.tocco.nice2.persist.hibernate.PersistenceService>`
+When a query builder instance is created using the :abbr:`PersistenceService (ch.tocco.nice2.persist.hibernate.PersistenceService)`
 it is possible to pass query hints in the form of a ``Map<String, ?>``.
-:java:ref:`QueryHints<ch.tocco.nice2.persist.hibernate.query.QueryHints>` are additional information for the query builder which can lead to an optimized query.
+:abbr:`QueryHints (ch.tocco.nice2.persist.hibernate.query.QueryHints)` are additional information for the query builder which can lead to an optimized query.
 
 Currently there is only one supported hint: ``QUERY_BY_KEYS``.
 
 ``QUERY_BY_KEYS`` defines all primary keys which might possibly be returned from the query. It is usually combined with a
 ``primaryKeyIn()`` condition.
 
-The hints are passed to the :java:ref:`PredicateBuilder<ch.tocco.nice2.persist.hibernate.query.PredicateBuilder>`
+The hints are passed to the :abbr:`PredicateBuilder (ch.tocco.nice2.persist.hibernate.query.PredicateBuilder)`
 which can use it build an optimized condition.

--- a/framework/architecture/hibernate/query-builder.rst
+++ b/framework/architecture/hibernate/query-builder.rst
@@ -496,7 +496,7 @@ are collected:
     * ``fieldUsedInQueryCondition(ROOT, "relUser")``
 
 :java-hibernate:`ParameterizedFunctionExpression <org/hibernate/query/criteria/internal/expression/function/ParameterizedFunctionExpression>`
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 All parameter expressions of the function call are recursively evaluated (see above how :java-javax:`Path <javax/persistence/criteria/Path>`
 expression are evaluated).

--- a/framework/architecture/hibernate/session-factory-provider.rst
+++ b/framework/architecture/hibernate/session-factory-provider.rst
@@ -4,20 +4,20 @@ Hibernate Setup
 Introduction
 ------------
 Hibernate is an implementation of the JPA specification, however we use the Hibernate API directly in many cases
-(instead of using the JPA API in the :java:extdoc:`javax.persistence` package), mostly because we need many custom Hibernate
+(instead of using the JPA API in the `javax.persistence <https://javaee.github.io/javaee-spec/javadocs/javax/persistence/package-summary.html>`__ package), mostly because we need many custom Hibernate
 features to be able to provide exactly the same behaviour as the old Persistence API did.
 
 Build the SessionFactory
 ------------------------
-The first step is to initialize a :java:extdoc:`SessionFactory<org.hibernate.SessionFactory>`.
-This is done by the :java:ref:`SessionFactoryProvider<ch.tocco.nice2.persist.hibernate.bootstrap.SessionFactoryProvider>`,
-which is a hivemind :java:ref:`ServiceImplementationFactory<org.apache.hivemind.ServiceImplementationFactory>`. This is a sort of a factory service that can be used to
-inject the generated object (in this case the :java:extdoc:`SessionFactory<org.hibernate.SessionFactory>`) into other services.
+The first step is to initialize a :java-hibernate:`SessionFactory <org/hibernate/SessionFactory>`.
+This is done by the :abbr:`SessionFactoryProvider (ch.tocco.nice2.persist.hibernate.bootstrap.SessionFactoryProvider)`,
+which is a hivemind :abbr:`ServiceImplementationFactory (org.apache.hivemind.ServiceImplementationFactory)`. This is a sort of a factory service that can be used to
+inject the generated object (in this case the :java-hibernate:`SessionFactory <org/hibernate/SessionFactory>`) into other services.
 
 The Hibernate bootstrapping process is documented `here <https://docs.jboss.org/hibernate/orm/5.2/userguide/html_single/Hibernate_User_Guide.html#bootstrap-native>`_.
 
 This service is registered with private visibility and can only be used in the ``persist/core`` module, because if other modules
-would use the :java:extdoc:`SessionFactory<org.hibernate.SessionFactory>` directly, they could bypass the security layer.
+would use the :java-hibernate:`SessionFactory <org/hibernate/SessionFactory>` directly, they could bypass the security layer.
 
 .. _bootstrap:
 
@@ -25,21 +25,21 @@ Participate in the bootstrap process
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 It is possible for other hivemind modules to apply custom configuration options during the building of the
-session factory by contributing a :java:ref:`HibernateBootstrapContribution<ch.tocco.nice2.persist.hibernate.HibernateBootstrapContribution>`.
+session factory by contributing a :abbr:`HibernateBootstrapContribution (ch.tocco.nice2.persist.hibernate.HibernateBootstrapContribution)`.
 This contribution provides several methods to participate in various steps of the bootstrapping process. It's also possible
 to provide a priority to control the execution order of the different contributions.
 This can for example be used for registering custom user types.
 
-The main configuration is done by :java:ref:`HibernateCoreBootstrapContribution<ch.tocco.nice2.persist.hibernate.bootstrap.HibernateCoreBootstrapContribution>`.
+The main configuration is done by :abbr:`HibernateCoreBootstrapContribution (ch.tocco.nice2.persist.hibernate.bootstrap.HibernateCoreBootstrapContribution)`.
 
 .. _classLoaderService:
 
 ContributionClassLoaderService
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The :java:ref:`ContributionClassLoaderService<ch.tocco.nice2.persist.hibernate.ContributionClassLoaderService>` is a custom
-:java:extdoc:`ClassLoaderService<org.hibernate.boot.registry.classloading.spi.ClassLoaderService>` which makes it easy
-to contribute services at runtime and to avoid having to use the :java:extdoc:`ServiceLoader<java.util.ServiceLoader>`
+The :abbr:`ContributionClassLoaderService (ch.tocco.nice2.persist.hibernate.ContributionClassLoaderService)` is a custom
+:java-hibernate:`ClassLoaderService <org/hibernate/boot/registry/classloading/spi/ClassLoaderService>` which makes it easy
+to contribute services at runtime and to avoid having to use the :java:`ServiceLoader <java/util/ServiceLoader>`
 API used by the default implementation.
 
 Bootstrap steps
@@ -48,19 +48,19 @@ Bootstrap steps
 Register custom user extensions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Several user extensions are registered with the :java:ref:`ContributionClassLoaderService<ch.tocco.nice2.persist.hibernate.ContributionClassLoaderService>`:
+Several user extensions are registered with the :abbr:`ContributionClassLoaderService (ch.tocco.nice2.persist.hibernate.ContributionClassLoaderService)`:
 
-    - For each custom user type a :java:extdoc:`TypeContributor<org.hibernate.boot.model.TypeContributor>` is contributed.
+    - For each custom user type a :java-hibernate:`TypeContributor <org/hibernate/boot/model/TypeContributor>` is contributed.
       There are some default types (for example ``binary`` or ``datetime``) that are always registered, but other modules can
       contribute user types as well (see :ref:`user-types`).
-    - :java:ref:`FieldGenerator<ch.tocco.nice2.persist.hibernate.pojo.FieldGenerator>` contributions (fields that are set
+    - :abbr:`FieldGenerator (ch.tocco.nice2.persist.hibernate.pojo.FieldGenerator)` contributions (fields that are set
       automatically by the framework, like the create/update timestamps and users) (see :ref:`generated-values`).
 
 Generate entity classes
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 Entity classes are generated based on the entity models and then registered
-with the provided :java:extdoc:`MetadataSources<org.hibernate.boot.MetadataSources>`.
+with the provided :java-hibernate:`MetadataSources <org/hibernate/boot/MetadataSources>`.
 
 See :doc:`entity-class-generation`.
 
@@ -68,58 +68,58 @@ Apply Hibernate properties
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The next step is to apply the Hibernate configuration settings.
-The interface :java:ref:`HibernatePropertiesProvider<ch.tocco.nice2.persist.hibernate.HibernatePropertiesProvider>`
+The interface :abbr:`HibernatePropertiesProvider (ch.tocco.nice2.persist.hibernate.HibernatePropertiesProvider)`
 defines some common properties in a default method.
 
-The only implementation (:java:ref:`HibernatePropertiesProviderImpl<ch.tocco.nice2.persist.hibernate.bootstrap.HibernatePropertiesProviderImpl>`)
+The only implementation (:abbr:`HibernatePropertiesProviderImpl (ch.tocco.nice2.persist.hibernate.bootstrap.HibernatePropertiesProviderImpl)`)
 adds the connection options to the default properties. These are read from the different ``hikaricp.properties`` files
 (base, customer and local).
 The properties need to be transformed to a different format as Hibernate uses different options than HikariCP.
 
-The :java:ref:`ToccoDialectResolver<ch.tocco.nice2.persist.hibernate.dialect.ToccoDialectResolver>` is a custom
-:java:extdoc:`DialectResolver<org.hibernate.engine.jdbc.dialect.spi.DialectResolver>`, which makes sure that our custom dialects are used
+The :abbr:`ToccoDialectResolver (ch.tocco.nice2.persist.hibernate.dialect.ToccoDialectResolver)` is a custom
+:java-hibernate:`DialectResolver <org/hibernate/engine/jdbc/dialect/spi/DialectResolver>`, which makes sure that our custom dialects are used
 by hibernate. It is configured using the ``hibernate.dialect_resolvers`` property.
 
 Injecting service factories
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-We use a custom implementation of :java:extdoc:`PersisterFactory<org.hibernate.persister.spi.PersisterFactory>`.
+We use a custom implementation of :java-hibernate:`PersisterFactory <org/hibernate/persister/spi/PersisterFactory>`.
 This allows (manually) injecting hivemind services or contributions into a custom persister or dialect.
 Without using a custom factory, Hibernate just calls the default constructor.
 
 Hibernate interceptor
 ^^^^^^^^^^^^^^^^^^^^^
 
-A custom Hibernate :java:extdoc:`Interceptor<org.hibernate.Interceptor>` is registered as well.
+A custom Hibernate :java-hibernate:`Interceptor <org/hibernate/Interceptor>` is registered as well.
 In order to be able to split up the functionality of the interceptor into different classes
-(perhaps from different modules) the :java:ref:`DelegatingHibernateInterceptor<ch.tocco.nice2.persist.hibernate.listener.DelegatingHibernateInterceptor>`
+(perhaps from different modules) the :abbr:`DelegatingHibernateInterceptor (ch.tocco.nice2.persist.hibernate.listener.DelegatingHibernateInterceptor)`
 is used (as it is not possible to register multiple interceptors). This class then delegates the events to the
 actual interceptor implementations.
 
 Currently only one interceptor is used:
 
-    - :java:ref:`ValidationInterceptor<ch.tocco.nice2.persist.hibernate.validation.ValidationInterceptor>` which runs the
+    - :abbr:`ValidationInterceptor (ch.tocco.nice2.persist.hibernate.validation.ValidationInterceptor)` which runs the
       entity validation before the changes are flushed to the database.
 
 JDBC function registration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-All :java:ref:`JdbcFunction<ch.tocco.nice2.persist.hibernate.query.JdbcFunction>` are registered with the
-:java:extdoc:`SessionFactoryBuilder<org.hibernate.boot.SessionFactoryBuilder>`.
+All :abbr:`JdbcFunction (ch.tocco.nice2.persist.hibernate.query.JdbcFunction)` are registered with the
+:java-hibernate:`SessionFactoryBuilder <org/hibernate/boot/SessionFactoryBuilder>`.
 
 Event listener registration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Multiple Hibernate listeners (see :java:extdoc:`EventType<org.hibernate.event.spi.EventType>`) are registered:
+Multiple Hibernate listeners (see :java-hibernate:`EventType <org/hibernate/event/spi/EventType>`) are registered:
 
-    - :java:ref:`ExtendedInitializeCollectionEventListener<ch.tocco.nice2.persist.hibernate.interceptor.ExtendedInitializeCollectionEventListener>`
+    - :abbr:`ExtendedInitializeCollectionEventListener (ch.tocco.nice2.persist.hibernate.interceptor.ExtendedInitializeCollectionEventListener)`
       initializes collections using a custom query which includes security and business unit predicates. See :doc:`collections`.
-    - :java:ref:`CustomDeleteEventListener<ch.tocco.nice2.persist.hibernate.cascade.CustomDeleteEventListener>` makes sure
+    - :abbr:`CustomDeleteEventListener (ch.tocco.nice2.persist.hibernate.cascade.CustomDeleteEventListener)` makes sure
       that deleted entities are automatically removed from many to many associations (see :ref:`delete_event_listener`).
-    - :java:ref:`CustomFlushEntityEventListener<ch.tocco.nice2.persist.hibernate.listener.CustomFlushEntityEventListener>` handles
+    - :abbr:`CustomFlushEntityEventListener (ch.tocco.nice2.persist.hibernate.listener.CustomFlushEntityEventListener)` handles
       custom after commit events (see :ref:`flush_event`)
-    - :java:ref:`AfterCommitListener<ch.tocco.nice2.persist.hibernate.listener.AfterCommitListener>` and
-      :java:ref:`CustomFlushEntityEventListener<ch.tocco.nice2.persist.hibernate.listener.CustomFlushEntityEventListener>`
+    - :abbr:`AfterCommitListener (ch.tocco.nice2.persist.hibernate.listener.AfterCommitListener)` and
+      :abbr:`CustomFlushEntityEventListener (ch.tocco.nice2.persist.hibernate.listener.CustomFlushEntityEventListener)`
       are responsible for firing after commit events (see :ref:`Listeners`).
 
 Startup time improvements
@@ -128,20 +128,20 @@ Startup time improvements
 Hibernate completely initializes every entity during the construction of the session factory.
 Among many other things this includes:
 
-    - A :java:extdoc:`ProxyFactory<org.hibernate.proxy.ProxyFactory>` for every entity (required to instantiate
+    - A :java-hibernate:`ProxyFactory <org/hibernate/proxy/ProxyFactory>` for every entity (required to instantiate
       lazily loaded entity proxies). These are currently based on javassist and take some time to initialize,
       especially for hundreds of entities.
-    - Several :java:extdoc:`UniqueEntityLoader<org.hibernate.loader.entity.UniqueEntityLoader>` per entity
-      (one per :java:extdoc:`LockMode<org.hibernate.LockMode>`). Apart from the fact that we don't need all lock modes,
+    - Several :java-hibernate:`UniqueEntityLoader <org/hibernate/loader/entity/UniqueEntityLoader>` per entity
+      (one per :java-hibernate:`LockMode <org/hibernate/LockMode>`). Apart from the fact that we don't need all lock modes,
       they are also expensive to initialize because they contain the SQL string required to load the entity.
 
 This makes sense for a production environment, but during development a quicker startup time is more important because
 usually only a fraction of all entities is used. It therefore makes more sense to initialize these objects on the fly when
 they are needed for the first time.
 
-To support this we use the :java:ref:`CustomEntityPersister<ch.tocco.nice2.persist.hibernate.CustomEntityPersister>` that
-returns a custom lazy implementation of :java:extdoc:`UniqueEntityLoader<org.hibernate.loader.entity.UniqueEntityLoader>`
+To support this we use the :abbr:`CustomEntityPersister (ch.tocco.nice2.persist.hibernate.CustomEntityPersister)` that
+returns a custom lazy implementation of :java-hibernate:`UniqueEntityLoader <org/hibernate/loader/entity/UniqueEntityLoader>`
 which is not initialized until it is needed.
 
-Similarly, the :java:ref:`CustomEntityTuplizer<ch.tocco.nice2.persist.hibernate.CustomEntityTuplizer>` does not initialize
-the :java:extdoc:`ProxyFactory<org.hibernate.proxy.ProxyFactory>` until it is needed.
+Similarly, the :abbr:`CustomEntityTuplizer (ch.tocco.nice2.persist.hibernate.CustomEntityTuplizer)` does not initialize
+the :java-hibernate:`ProxyFactory <org/hibernate/proxy/ProxyFactory>` until it is needed.

--- a/framework/architecture/hibernate/session-lifecycle.rst
+++ b/framework/architecture/hibernate/session-lifecycle.rst
@@ -1,33 +1,33 @@
 Session Lifecycle
 =================
 
-The Hibernate :java:extdoc:`Session<org.hibernate.Session>` is the equivalent of the :java:ref:`Context<ch.tocco.nice2.persist.Context>`
+The Hibernate :java-hibernate:`Session <org/hibernate/Session>` is the equivalent of the :abbr:`Context (ch.tocco.nice2.persist.Context)`
 of the nice2 Persistence API.
-The implementation (:java:ref:`ContextAdapter<ch.tocco.nice2.persist.hibernate.legacy.ContextAdapter>`) of the Context
+The implementation (:abbr:`ContextAdapter (ch.tocco.nice2.persist.hibernate.legacy.ContextAdapter)`) of the Context
 interface references exactly one session.
 
 ContextService
 --------------
 
-The :java:ref:`ContextService<ch.tocco.nice2.persist.hibernate.legacy.ContextService>` is a service that implements
-the :java:ref:`Context<ch.tocco.nice2.persist.Context>` interface.
-This is the implementation that is injected into other services, when they need to access the :java:ref:`Context<ch.tocco.nice2.persist.Context>`.
+The :abbr:`ContextService (ch.tocco.nice2.persist.hibernate.legacy.ContextService)` is a service that implements
+the :abbr:`Context (ch.tocco.nice2.persist.Context)` interface.
+This is the implementation that is injected into other services, when they need to access the :abbr:`Context (ch.tocco.nice2.persist.Context)`.
 It is important to properly close a session to avoid memory leaks.
 
 Implicitly and explicitly created contexts
 ------------------------------------------
 
 There is exactly one implicit context per thread, which is created when the current context is accessed for
-the first time (typically through the :java:ref:`ContextService<ch.tocco.nice2.persist.hibernate.legacy.ContextService>`).
+the first time (typically through the :abbr:`ContextService (ch.tocco.nice2.persist.hibernate.legacy.ContextService)`).
 Unless the user manually creates additional contexts, all the persistence calls are handled by the implicit context.
-It is stored in a :java:extdoc:`ThreadLocal<java.lang.ThreadLocal>` variable in the :java:ref:`ContextManagerAdapter<ch.tocco.nice2.persist.hibernate.legacy.ContextManagerAdapter>`.
-The implicit context is automatically closed when the underlying session will be closed by the :java:ref:`SessionFactoryManager<ch.tocco.nice2.persist.hibernate.session.SessionFactoryManager>`.
+It is stored in a :java:`ThreadLocal <java/lang/ThreadLocal>` variable in the :abbr:`ContextManagerAdapter (ch.tocco.nice2.persist.hibernate.legacy.ContextManagerAdapter)`.
+The implicit context is automatically closed when the underlying session will be closed by the :abbr:`SessionFactoryManager (ch.tocco.nice2.persist.hibernate.session.SessionFactoryManager)`.
 
 Sometimes it is necessary to create an isolated context for specific work. New contexts can be created by the
-:java:ref:`ContextManager<ch.tocco.nice2.persist.ContextManager>`. Unlike the implicit context, all additional contexts
+:abbr:`ContextManager (ch.tocco.nice2.persist.ContextManager)`. Unlike the implicit context, all additional contexts
 must be manually closed by the user.
 
-The :java:ref:`ContextManagerAdapter<ch.tocco.nice2.persist.hibernate.legacy.ContextManagerAdapter>` maintains a
+The :abbr:`ContextManagerAdapter (ch.tocco.nice2.persist.hibernate.legacy.ContextManagerAdapter)` maintains a
 map which keeps track of all explicitly created contexts. This is necessary to be able to find a specific context instance by the
 session it references.
 
@@ -42,23 +42,23 @@ Current session and current context
 Current session
 ^^^^^^^^^^^^^^^
 
-If the current session is requested from the :java:extdoc:`SessionFactory<org.hibernate.SessionFactory>` the call is delegated
-to an implementation of :java:extdoc:`CurrentSessionContext<org.hibernate.context.spi.CurrentSessionContext>`.
-We configure the :java:extdoc:`ManagedSessionContext<org.hibernate.context.internal.ManagedSessionContext>` by
-setting the property ``hibernate.current_session_context_class`` (see :java:ref:`HibernatePropertiesProvider<ch.tocco.nice2.persist.hibernate.HibernatePropertiesProvider>`).
+If the current session is requested from the :java-hibernate:`SessionFactory <org/hibernate/SessionFactory>` the call is delegated
+to an implementation of :java-hibernate:`CurrentSessionContext <org/hibernate/context/spi/CurrentSessionContext>`.
+We configure the :java-hibernate:`ManagedSessionContext <org/hibernate/context/internal/ManagedSessionContext>` by
+setting the property ``hibernate.current_session_context_class`` (see :abbr:`HibernatePropertiesProvider (ch.tocco.nice2.persist.hibernate.HibernatePropertiesProvider)`).
 
 The ManagedSessionContext requires the Session to be set explicitly when the current session is requested, otherwise an exception will be thrown.
-In contrast, the previously used :java:extdoc:`ThreadLocalSessionContext<org.hibernate.context.internal.ThreadLocalSessionContext>` creates a new session when none was set, but it's a 'protected'
+In contrast, the previously used :java-hibernate:`ThreadLocalSessionContext <org/hibernate/context/internal/ThreadLocalSessionContext>` creates a new session when none was set, but it's a 'protected'
 session that always requires a transaction and is not compatible with our API.
 Thus it's better to just throw an exception when no session was set explicitly (as this should never occur anyway).
 
 SessionFactoryManager
 ~~~~~~~~~~~~~~~~~~~~~
 
-The :java:ref:`SessionFactoryManager<ch.tocco.nice2.persist.hibernate.session.SessionFactoryManager>` manages the hibernate sessions.
+The :abbr:`SessionFactoryManager (ch.tocco.nice2.persist.hibernate.session.SessionFactoryManager)` manages the hibernate sessions.
 All access to hibernate sessions should be made through this class!
-This central management of sessions makes sure that the old :java:ref:`Context<ch.tocco.nice2.persist.Context>`
-based API can be used in combination with the new :java:ref:`PersistenceService<ch.tocco.nice2.persist.hibernate.PersistenceService>`.
+This central management of sessions makes sure that the old :abbr:`Context (ch.tocco.nice2.persist.Context)`
+based API can be used in combination with the new :abbr:`PersistenceService (ch.tocco.nice2.persist.hibernate.PersistenceService)`.
 
 For example, when a new implicit session is created because the PersistenceService API has been accessed, ``ContextManager#getThreadContext()``
 realizes that the implicit session already exists (even though no implicit Context instance exists yet) and re-uses this session.
@@ -68,30 +68,30 @@ layer is accessed for the first time during a request and no session has been op
 
 If the current session is requested (``getCurrentSession()``), the session bound to the ManagedSessionContext is returned.
 If nothing is bound, the implicit session is returned (and created if necessary) and bound to the ManagedSessionContext.
-For every implicit context a :java:ref:`ThreadCleanupListener<org.apache.hivemind.service.ThreadCleanupListener>` is registered
+For every implicit context a :abbr:`ThreadCleanupListener (org.apache.hivemind.service.ThreadCleanupListener)` is registered
 that detaches and closes the implicit session at the end of the request.
 
 It is also possible to explicitly create a new session (using ``createNewSession()``). Explicitly created sessions
 are always bound to the ManagedSessionContext. Explicitly created sessions need to be closed manually!
-A :java:extdoc:`BaseSessionEventListener<org.hibernate.BaseSessionEventListener>` is registered with the session
+A :java-hibernate:`BaseSessionEventListener <org/hibernate/BaseSessionEventListener>` is registered with the session
 which detaches the closed session and re-attaches the previous session (if there was one).
 
-A :java:ref:`SessionFactoryManagerListener<ch.tocco.nice2.persist.hibernate.session.SessionFactoryManagerListener>` can be registered
+A :abbr:`SessionFactoryManagerListener (ch.tocco.nice2.persist.hibernate.session.SessionFactoryManagerListener)` can be registered
 with the SessionFactoryManager. It's ``sessionClosing()`` method is called for every session that is about to be closed.
 
 Current context
 ^^^^^^^^^^^^^^^
 
-The current :java:ref:`Context<ch.tocco.nice2.persist.Context>` is always the context which references the current session.
+The current :abbr:`Context (ch.tocco.nice2.persist.Context)` is always the context which references the current session.
 ``ContextManagerAdapter#getThreadContext()`` returns the current context:
 
-    - The current session is retrieved from the :java:ref:`SessionFactoryManager<ch.tocco.nice2.persist.hibernate.session.SessionFactoryManager>`
+    - The current session is retrieved from the :abbr:`SessionFactoryManager (ch.tocco.nice2.persist.hibernate.session.SessionFactoryManager)`
       (this might create a new implicit session)
     - Check if there is an explicitly created context belonging to this sessions and return it (explicitly created contexts are
       cached in a ``Map``)
     - Check if the current session is the implicit session. If yes, check if there already is an implicit context instance
       for this thread and return it. If not, create a new implicit context instance and store it in the ThreadLocal. A
-      :java:extdoc:`BaseSessionEventListener<org.hibernate.BaseSessionEventListener>` is added to this session, to make sure
+      :java-hibernate:`BaseSessionEventListener <org/hibernate/BaseSessionEventListener>` is added to this session, to make sure
       that the ThreadLocal is cleared when the implicit session is closed.
     - If none of the above applies, it must be an explicitly opened session --> create a context instance for it
 
@@ -100,7 +100,7 @@ Setting the current context
 
 The current session is set (or removed) when ``ContextAdapter#suspend()`` or ``ContextAdapter#resume()`` is called.
 The session of that context is then bound to or detached from the current thread using the ``attachSessionToThread()``
-or ``detachSessionFromThread()`` methods of the :java:ref:`SessionFactoryManager<ch.tocco.nice2.persist.hibernate.session.SessionFactoryManager>`.
+or ``detachSessionFromThread()`` methods of the :abbr:`SessionFactoryManager (ch.tocco.nice2.persist.hibernate.session.SessionFactoryManager)`.
 ``ContextAdapter#resume()`` is called by default when a new context is created.
 
 Flush mode

--- a/framework/architecture/hibernate/sql-logging.rst
+++ b/framework/architecture/hibernate/sql-logging.rst
@@ -20,22 +20,22 @@ First a ``spy.properties`` file has to be created which configures an appender f
 A reference to this file needs to be passed as a command line argument when Nice2 is started:
 ``-Dspy.properties=../../persist/core/module/spy.properties``
 
-In addition a custom JDBC Driver (:java:ref:`P6SpyDriver<com.p6spy.engine.spy.P6SpyDriver>`) and JDBC url (``jdbc:p6spy:postgresql://...``) needs to be used.
-This is configured in the :java:ref:`HibernatePropertiesBuilder<ch.tocco.nice2.persist.hibernate.HibernatePropertiesBuilder>`.
+In addition a custom JDBC Driver (:abbr:`P6SpyDriver (com.p6spy.engine.spy.P6SpyDriver)`) and JDBC url (``jdbc:p6spy:postgresql://...``) needs to be used.
+This is configured in the :abbr:`HibernatePropertiesBuilder (ch.tocco.nice2.persist.hibernate.HibernatePropertiesBuilder)`.
 The p6spy driver is currently only configured for the ``development`` environment.
 
 Logging
 -------
 
-All statements are passed to the configured :java:ref:`NiceLogger<ch.tocco.nice2.persist.hibernate.spy.NiceLogger>` by the
+All statements are passed to the configured :abbr:`NiceLogger (ch.tocco.nice2.persist.hibernate.spy.NiceLogger)` by the
 p6spy driver.
 
-To decouple the SQL statement consumers from p6spy the :java:ref:`SpyLoggerService<ch.tocco.nice2.persist.hibernate.spy.SpyLoggerService>`
+To decouple the SQL statement consumers from p6spy the :abbr:`SpyLoggerService (ch.tocco.nice2.persist.hibernate.spy.SpyLoggerService)`
 acts as a bridge between the logger and the consumers.
 Consumers can register with the service and receive the SQL statement events. Currently the only consumer is the
-:java:ref:`SqlLogViewModel<ch.tocco.nice2.devcon.views.persist.sqllogger.SqlLogViewModel>` which publishes the statements
+:abbr:`SqlLogViewModel (ch.tocco.nice2.devcon.views.persist.sqllogger.SqlLogViewModel)` which publishes the statements
 to the DevCon.
 
-The :java:ref:`NiceLogger<ch.tocco.nice2.persist.hibernate.spy.NiceLogger>` publishes the SQL statements to the
-:java:ref:`SpyLoggerService<ch.tocco.nice2.persist.hibernate.spy.SpyLoggerService>`.
+The :abbr:`NiceLogger (ch.tocco.nice2.persist.hibernate.spy.NiceLogger)` publishes the SQL statements to the
+:abbr:`SpyLoggerService (ch.tocco.nice2.persist.hibernate.spy.SpyLoggerService)`.
 

--- a/framework/architecture/hibernate/transaction-lifecycle.rst
+++ b/framework/architecture/hibernate/transaction-lifecycle.rst
@@ -10,17 +10,17 @@ TransactionControl
 
 There are several ways to start a transaction:
 
-* using the :java:ref:`TxInvoker<ch.tocco.nice2.persist.impl.entity.TxInvoker>` obtained from ``Context#tx()``
-* using the :java:ref:`TransactionManager<ch.tocco.nice2.persist.tx.TransactionManager>` directly
-* using the :java:ref:`PersistenceService<ch.tocco.nice2.persist.hibernate.PersistenceService>` of the new API
+* using the :abbr:`TxInvoker (ch.tocco.nice2.persist.impl.entity.TxInvoker)` obtained from ``Context#tx()``
+* using the :abbr:`TransactionManager (ch.tocco.nice2.persist.tx.TransactionManager)` directly
+* using the :abbr:`PersistenceService (ch.tocco.nice2.persist.hibernate.PersistenceService)` of the new API
 
-Independently of how the transaction was started, in the background an instance of :java:ref:`TransactionControl<ch.tocco.nice2.persist.hibernate.TransactionControl>`
+Independently of how the transaction was started, in the background an instance of :abbr:`TransactionControl (ch.tocco.nice2.persist.hibernate.TransactionControl)`
 will be created. No matter through which API the transaction is accessed, always the same transaction control instance
 is used per transaction.
 
 The transaction control has the following responsibilities:
 
-* it encapsulates the actual Hibernate :java:extdoc:`Transaction<org.hibernate.Transaction>`
+* it encapsulates the actual Hibernate :java-hibernate:`Transaction <org/hibernate/Transaction>`
 * commit or rollback of the transaction
 * firing of commit listeners
 * handling of created and deleted entities
@@ -31,29 +31,29 @@ Commit Listeners
 CommitListener
 ^^^^^^^^^^^^^^
 
-A :java:ref:`CommitListener<ch.tocco.nice2.persist.hibernate.listener.CommitListener>` can be registered with the
-:java:ref:`EntityFacadeListenerManager<ch.tocco.nice2.persist.hibernate.listener.EntityFacadeListenerManager>` for
+A :abbr:`CommitListener (ch.tocco.nice2.persist.hibernate.listener.CommitListener)` can be registered with the
+:abbr:`EntityFacadeListenerManager (ch.tocco.nice2.persist.hibernate.listener.EntityFacadeListenerManager)` for
 a specific session.
 
-Commit listeners implemented using the interface of the old API (:java:ref:`CommitListener<ch.tocco.nice2.persist.util.CommitListener>`)
-are registered by the :java:ref:`Context<ch.tocco.nice2.persist.Context>` using an adapter class.
+Commit listeners implemented using the interface of the old API (:abbr:`CommitListener (ch.tocco.nice2.persist.util.CommitListener)`)
+are registered by the :abbr:`Context (ch.tocco.nice2.persist.Context)` using an adapter class.
 
 These listeners are meant to be used by the business code to run actions before or after a commit (or rollback).
 
 TransactionListener
 ^^^^^^^^^^^^^^^^^^^
 
-The :java:ref:`TransactionListener<ch.tocco.nice2.persist.hibernate.TransactionListener>` can be registered
+The :abbr:`TransactionListener (ch.tocco.nice2.persist.hibernate.TransactionListener)` can be registered
 directly on the transaction control and is meant to be used by internal code and are used to clean up the transaction.
 
-:java:ref:`TransactionAware<ch.tocco.nice2.persist.tx.TransactionAware>` instances which are registered on the
-:java:ref:`TransactionAdapter<ch.tocco.nice2.persist.hibernate.legacy.TransactionAdapter>` are also added as
-:java:ref:`TransactionListener<ch.tocco.nice2.persist.hibernate.TransactionListener>` using an adapter class.
+:abbr:`TransactionAware (ch.tocco.nice2.persist.tx.TransactionAware)` instances which are registered on the
+:abbr:`TransactionAdapter (ch.tocco.nice2.persist.hibernate.legacy.TransactionAdapter)` are also added as
+:abbr:`TransactionListener (ch.tocco.nice2.persist.hibernate.TransactionListener)` using an adapter class.
 
 Transaction context
 -------------------
 
-The :java:ref:`EntityTransactionContext<ch.tocco.nice2.persist.hibernate.cascade.EntityTransactionContext>` keeps
+The :abbr:`EntityTransactionContext (ch.tocco.nice2.persist.hibernate.cascade.EntityTransactionContext)` keeps
 track of all entities that are created or deleted during the transaction and executes these changes before the
 transaction is committed.
 
@@ -63,8 +63,8 @@ Validation
 ----------
 
 Entities that have been created or modified during a transaction will be validated before the transaction is committed.
-The validation is started by the :java:ref:`ValidationInterceptor<ch.tocco.nice2.persist.hibernate.validation.ValidationInterceptor>`
-(which is a Hibernate :java:extdoc:`Interceptor<org.hibernate.Interceptor>`).
+The validation is started by the :abbr:`ValidationInterceptor (ch.tocco.nice2.persist.hibernate.validation.ValidationInterceptor)`
+(which is a Hibernate :java-hibernate:`Interceptor <org/hibernate/Interceptor>`).
 
 The ``onSave()`` event is called for every entity instance that is created during the transaction (before it is saved to the
 database using ``Session#save()`` by the :ref:`transaction-context` - not when the entity instance is created).

--- a/framework/architecture/hibernate/user-types.rst
+++ b/framework/architecture/hibernate/user-types.rst
@@ -4,17 +4,17 @@ Custom user types
 =================
 
 Per default Hibernate can map all primitive types (and its wrapper classes) as well as references to other entities.
-For all other classes that need to be mapped to the database an :java:extdoc:`UserType<org.hibernate.usertype.UserType>`
-must be implemented (for immutable types the base class :java:ref:`ImmutableUserType<ch.tocco.nice2.persist.hibernate.usertype.ImmutableUserType>`
-can be used). The user type contains the logic how a specific object should be read from the :java:extdoc:`ResultSet<java.sql.ResultSet>`
-and written to the :java:extdoc:`PreparedStatement<java.sql.PreparedStatement>`.
+For all other classes that need to be mapped to the database an :java-hibernate:`UserType <org/hibernate/usertype/UserType>`
+must be implemented (for immutable types the base class :abbr:`ImmutableUserType (ch.tocco.nice2.persist.hibernate.usertype.ImmutableUserType)`
+can be used). The user type contains the logic how a specific object should be read from the :java:`ResultSet <java/sql/ResultSet>`
+and written to the :java:`PreparedStatement <java/sql/PreparedStatement>`.
 
-For example the :java:ref:`Login<ch.tocco.nice2.types.Login>` class is mapped with a custom user type (:java:ref:`LoginUserType<ch.tocco.nice2.persist.hibernate.usertype.LoginUserType>`).
+For example the :abbr:`Login (ch.tocco.nice2.types.Login)` class is mapped with a custom user type (:abbr:`LoginUserType (ch.tocco.nice2.persist.hibernate.usertype.LoginUserType)`).
 
 *There are two ways to register a new user type:*
 
 It can be registered with a bootstrap contribution (see :ref:`bootstrap`). This way should be used if
-there is a distinct object which should be mapped (for example :java:ref:`Login<ch.tocco.nice2.types.Login>`):
+there is a distinct object which should be mapped (for example :abbr:`Login (ch.tocco.nice2.types.Login)`):
 
 .. code-block:: java
 
@@ -35,7 +35,7 @@ The alternative is to bind the user type to a field type (like ``phone``) using 
 .. note::
 
     User types are going to be deprecated in Hibernate 6+ and some refactoring will be required.
-    One attempt to replace them with :java:extdoc:`AttributeConverter<javax.persistence.AttributeConverter>`
+    One attempt to replace them with :java-javax:`AttributeConverter <javax/persistence/AttributeConverter>`
     was not successful due to classloading issues with hivemind.
 
 Simple user types
@@ -43,49 +43,49 @@ Simple user types
 
 Most user types are relatively simple and only map between a string or number and an object:
 
-    * :java:ref:`EncodedPasswordUserType<ch.tocco.nice2.security.spi.auth.hibernate.EncodedPasswordUserType>` maps
-      instances of :java:ref:`EncodedPassword<ch.tocco.nice2.types.spi.password.EncodedPassword>` from/to a string.
-    * :java:ref:`LoginUserType<ch.tocco.nice2.persist.hibernate.usertype.LoginUserType>` maps
-      instances of :java:ref:`Login<ch.tocco.nice2.types.Login>` from/to a string.
-    * :java:ref:`UuidToStringUserType<ch.tocco.nice2.persist.hibernate.usertype.UuidToStringUserType>` maps
-      instances of :java:extdoc:`UUID<java.util.UUID>` from/to a string.
-    * :java:ref:`GeolocationTypesContribution<ch.tocco.nice2.optional.geolocation.impl.type.GeolocationTypesContribution>` contains
-      user types that support :java:ref:`Latitude<ch.tocco.nice2.types.spi.geolocation.Latitude>` and :java:ref:`Longitude<ch.tocco.nice2.types.spi.geolocation.Longitude>` objects.
+    * :abbr:`EncodedPasswordUserType (ch.tocco.nice2.security.spi.auth.hibernate.EncodedPasswordUserType)` maps
+      instances of :abbr:`EncodedPassword (ch.tocco.nice2.types.spi.password.EncodedPassword)` from/to a string.
+    * :abbr:`LoginUserType (ch.tocco.nice2.persist.hibernate.usertype.LoginUserType)` maps
+      instances of :abbr:`Login (ch.tocco.nice2.types.Login)` from/to a string.
+    * :abbr:`UuidToStringUserType (ch.tocco.nice2.persist.hibernate.usertype.UuidToStringUserType)` maps
+      instances of :java:`UUID <java/util/UUID>` from/to a string.
+    * :abbr:`GeolocationTypesContribution (ch.tocco.nice2.optional.geolocation.impl.type.GeolocationTypesContribution)` contains
+      user types that support :abbr:`Latitude (ch.tocco.nice2.types.spi.geolocation.Latitude)` and :abbr:`Longitude (ch.tocco.nice2.types.spi.geolocation.Longitude)` objects.
 
 ``phone`` type
 --------------
 
-The :java:ref:`PhoneUserType<ch.tocco.nice2.entityoperation.impl.phone.PhoneUserType>` is applied for all field
+The :abbr:`PhoneUserType (ch.tocco.nice2.entityoperation.impl.phone.PhoneUserType)` is applied for all field
 of the virtual ``phone`` type.
 This user type does not convert between different objects, but formats the phone number using the
-:java:ref:`PhoneFormatter<ch.tocco.nice2.toolbox.phone.PhoneFormatter>` whenever a ``phone`` value
+:abbr:`PhoneFormatter (ch.tocco.nice2.toolbox.phone.PhoneFormatter)` whenever a ``phone`` value
 is written to the database.
 
 ``html`` type
 -------------
 
-Like the :java:ref:`PhoneUserType<ch.tocco.nice2.entityoperation.impl.phone.PhoneUserType>`, the
-:java:ref:`HtmlUserType<ch.tocco.nice2.persist.hibernate.usertype.HtmlUserType>` does not convert between different objects
+Like the :abbr:`PhoneUserType (ch.tocco.nice2.entityoperation.impl.phone.PhoneUserType)`, the
+:abbr:`HtmlUserType (ch.tocco.nice2.persist.hibernate.usertype.HtmlUserType)` does not convert between different objects
 but does some string formatting for ``html`` fields.
 
-The formatting behaviour can be contributed using a :java:ref:`HtmlUserTypeExtension<ch.tocco.nice2.persist.hibernate.usertype.HtmlUserTypeExtension>`.
-Currently there is only the :java:ref:`PreserveFreemarkerOperatorsHtmlUserTypeExtension<ch.tocco.nice2.templating.impl.freemarker.usertype.PreserveFreemarkerOperatorsHtmlUserTypeExtension>`
+The formatting behaviour can be contributed using a :abbr:`HtmlUserTypeExtension (ch.tocco.nice2.persist.hibernate.usertype.HtmlUserTypeExtension)`.
+Currently there is only the :abbr:`PreserveFreemarkerOperatorsHtmlUserTypeExtension (ch.tocco.nice2.templating.impl.freemarker.usertype.PreserveFreemarkerOperatorsHtmlUserTypeExtension)`
 which handles escaping in freemarker expressions.
 
 ``binary`` type
 ---------------
 
-The :java:ref:`BinaryUserType<ch.tocco.nice2.persist.hibernate.usertype.BinaryUserType>` handles the :java:ref:`Binary<ch.tocco.nice2.persist.entity.Binary>`
+The :abbr:`BinaryUserType (ch.tocco.nice2.persist.hibernate.usertype.BinaryUserType)` handles the :abbr:`Binary (ch.tocco.nice2.persist.entity.Binary)`
 class. The column of a ``binary`` field contains the hash code of the binary and references the ``_nice_binary`` table.
 
-In addition to the mapping of the hash code this user type also calls the configured :java:ref:`BinaryAccessProvider<ch.tocco.nice2.persist.spi.binary.BinaryAccessProvider>`
+In addition to the mapping of the hash code this user type also calls the configured :abbr:`BinaryAccessProvider (ch.tocco.nice2.persist.spi.binary.BinaryAccessProvider)`
 which stores the binary data if necessary.
 
-User types are also used to map query parameters. If a :java:ref:`Binary<ch.tocco.nice2.persist.entity.Binary>` object is
+User types are also used to map query parameters. If a :abbr:`Binary (ch.tocco.nice2.persist.entity.Binary)` object is
 used as a query parameter, it should obviously not be attempted to write it to the binary data store!
 Therefore the binary content is only saved if ``Binary#mayBeStored()`` returns true.
-If a hash code is used as a query parameter for a binary field, the string is converted to a :java:ref:`BinaryQueryParameter<ch.tocco.nice2.persist.hibernate.legacy.BinaryQueryParameter>`
-by the :java:ref:`StringToBinaryParameterConverter<ch.tocco.nice2.persist.hibernate.legacy.StringToBinaryParameterConverter>`.
+If a hash code is used as a query parameter for a binary field, the string is converted to a :abbr:`BinaryQueryParameter (ch.tocco.nice2.persist.hibernate.legacy.BinaryQueryParameter)`
+by the :abbr:`StringToBinaryParameterConverter (ch.tocco.nice2.persist.hibernate.legacy.StringToBinaryParameterConverter)`.
 ``BinaryQueryParameter#mayBeStored()`` returns false so it can safely be used in queries.
 
 See chapter :ref:`large_objects` for more details about large objects.

--- a/framework/architecture/history/implementation.rst
+++ b/framework/architecture/history/implementation.rst
@@ -1,81 +1,81 @@
 Entity History Implementation
 =============================
 
-The entry point for the history implementation is the :java:ref:`HistoryService<ch.tocco.nice2.persist.history.v2.HistoryService>`.
-This class is a :java:ref:`ContextCreationListener<ch.tocco.nice2.persist.ContextCreationListener>`, which means that
-it will be notified if a new :java:ref:`Context<ch.tocco.nice2.persist.Context>` is created.
+The entry point for the history implementation is the :abbr:`HistoryService (ch.tocco.nice2.persist.history.v2.HistoryService)`.
+This class is a :abbr:`ContextCreationListener (ch.tocco.nice2.persist.ContextCreationListener)`, which means that
+it will be notified if a new :abbr:`Context (ch.tocco.nice2.persist.Context)` is created.
 
 In order for this to work properly it needs to be loaded eagerly (``hiveapp.EagerLoad`` contribution) so that the
-service can register itself with the :java:ref:`ContextManager<ch.tocco.nice2.persist.ContextManager>` when the application
+service can register itself with the :abbr:`ContextManager (ch.tocco.nice2.persist.ContextManager)` when the application
 is initialized.
 
-Whenever a new :java:ref:`Context<ch.tocco.nice2.persist.Context>` is created, several listeners will be
+Whenever a new :abbr:`Context (ch.tocco.nice2.persist.Context)` is created, several listeners will be
 added to the new context (all these listeners are removed again when the context is closed):
 
 HistoryEntityFacadeListener
 ---------------------------
 
-This listener is an :java:ref:`EntityFacadeListener<ch.tocco.nice2.persist.entity.events.EntityFacadeListener>`,
+This listener is an :abbr:`EntityFacadeListener (ch.tocco.nice2.persist.entity.events.EntityFacadeListener)`,
 which will be notified about all entity changes during a transaction.
 
 Every entity that is modified during the transaction is stored in the context attribute ``history-snapshots-entities``.
 Before the entity is stored, it is checked whether it should be included in the history using the
-:java:ref:`HistoryConfiguration<ch.tocco.nice2.persist.history.v2.config.HistoryConfiguration>` (a particular entity model
+:abbr:`HistoryConfiguration (ch.tocco.nice2.persist.history.v2.config.HistoryConfiguration)` (a particular entity model
 might be excluded from the history or the history might be disabled entirely).
 
 PrepareHistoryDataListener
 --------------------------
 
-This listeners is a :java:ref:`TransactionAware<ch.tocco.nice2.persist.tx.TransactionAware>` that is registered by the
-:java:ref:`HistoryService<ch.tocco.nice2.persist.history.v2.HistoryService>` with every newly created transaction.
+This listeners is a :abbr:`TransactionAware (ch.tocco.nice2.persist.tx.TransactionAware)` that is registered by the
+:abbr:`HistoryService (ch.tocco.nice2.persist.history.v2.HistoryService)` with every newly created transaction.
 
-The ``prepareCommit`` method of the :java:ref:`TransactionAware<ch.tocco.nice2.persist.tx.TransactionAware>` is called
+The ``prepareCommit`` method of the :abbr:`TransactionAware (ch.tocco.nice2.persist.tx.TransactionAware)` is called
 after all other listeners have already ran, so we can be sure that all changes have been captured by the
 HistoryEntityFacadeListener at this point.
 
 All entities that have been saved in the ``history-snapshots-entities`` attribute will be converted
-into a :java:ref:`DetachedEntity<ch.tocco.nice2.persist.history.v2.DetachedEntity>`, which contains all necessary information
+into a :abbr:`DetachedEntity (ch.tocco.nice2.persist.history.v2.DetachedEntity)`, which contains all necessary information
 for the snapshot that will be saved to the database. This has to be done before the commit, as some information is no longer available after commit
 (changed fields for example).
 
 Which fields and relations will be included in the snapshot depends on the entity model and is defined by the
-:java:ref:`HistoryConfiguration<ch.tocco.nice2.persist.history.v2.config.HistoryConfiguration>`.
+:abbr:`HistoryConfiguration (ch.tocco.nice2.persist.history.v2.config.HistoryConfiguration)`.
 
-All the created :java:ref:`DetachedEntity<ch.tocco.nice2.persist.history.v2.DetachedEntity>` are stored in the context attribute ``history-detached-entities``
+All the created :abbr:`DetachedEntity (ch.tocco.nice2.persist.history.v2.DetachedEntity)` are stored in the context attribute ``history-detached-entities``
 (the attribute ``history-snapshots-entities`` will be removed at this point).
 
 HistoryWriter
 -------------
 
-This :java:ref:`CommitListener<ch.tocco.nice2.persist.util.CommitListener>` is executed after the transaction is committed
+This :abbr:`CommitListener (ch.tocco.nice2.persist.util.CommitListener)` is executed after the transaction is committed
 (to make sure that the history is only written when the transaction has been committed successfully).
-All the :java:ref:`DetachedEntity<ch.tocco.nice2.persist.history.v2.DetachedEntity>` instances are read from the context attribute ``history-detached-entities``
-and converted to an XML format using the XStream library. The XML structure is defined in the :java:ref:`DetachedEntityMarshaller<ch.tocco.nice2.persist.history.v2.DetachedEntityMarshaller>`
+All the :abbr:`DetachedEntity (ch.tocco.nice2.persist.history.v2.DetachedEntity)` instances are read from the context attribute ``history-detached-entities``
+and converted to an XML format using the XStream library. The XML structure is defined in the :abbr:`DetachedEntityMarshaller (ch.tocco.nice2.persist.history.v2.DetachedEntityMarshaller)`
 and is exactly the same as in the previous history implementation (in order to be compatible with older history entries).
 The XML String is gzipped before it is saved to save storage space.
 
 The compressed XML data (along with other data like the username and ip address) are passed to the
-:java:ref:`HistoryDataStore<ch.tocco.nice2.persist.history.store.HistoryDataStore>` where they are persisted
+:abbr:`HistoryDataStore (ch.tocco.nice2.persist.history.store.HistoryDataStore)` where they are persisted
 in a dedicated history postgresql database. This is done asynchronously in a separate thread for performance reasons.
 
 HistoryConfiguration
 --------------------
 
-The :java:ref:`HistoryConfiguration<ch.tocco.nice2.persist.history.v2.config.HistoryConfiguration>` contains all information
+The :abbr:`HistoryConfiguration (ch.tocco.nice2.persist.history.v2.config.HistoryConfiguration)` contains all information
 whether the history is enabled for a certain entity model and if yes, which fields and relations should be included.
 
 The history can be globally disabled using the ``nice2.persist.history.enabled`` property.
 In addition it can also be disabled for specific entity models using the ``IgnoredEntityModels`` contribution.
 Obviously no history entries will be created for session-only entities.
 
-Which fields and relations are included in the snapshot is controlled by the :java:ref:`EntityHistoryConfiguration<ch.tocco.nice2.persist.history.v2.EntityHistoryConfiguration>`.
-There are default implementations for standard (:java:ref:`DefaultEntityHistoryConfig<ch.tocco.nice2.persist.history.v2.config.DefaultEntityHistoryConfig>`)
-and lookup entities (:java:ref:`LookupEntityHistoryConfig<ch.tocco.nice2.persist.history.v2.config.LookupEntityHistoryConfig>`).
+Which fields and relations are included in the snapshot is controlled by the :abbr:`EntityHistoryConfiguration (ch.tocco.nice2.persist.history.v2.EntityHistoryConfiguration)`.
+There are default implementations for standard (:abbr:`DefaultEntityHistoryConfig (ch.tocco.nice2.persist.history.v2.config.DefaultEntityHistoryConfig)`)
+and lookup entities (:abbr:`LookupEntityHistoryConfig (ch.tocco.nice2.persist.history.v2.config.LookupEntityHistoryConfig)`).
 The ``IgnoredEntityModels`` contribution mentioned above can also be used the further refine the default implementations
 by removing certain fields and relations from the snapshot.
 
 However it is also possible to completely customize the history snapshot with a custom implementation (see
-:java:ref:`PageEntityHistoryConfiguration<ch.tocco.nice2.optional.cms.impl.history.PageEntityHistoryConfiguration>` for example).
+:abbr:`PageEntityHistoryConfiguration (ch.tocco.nice2.optional.cms.impl.history.PageEntityHistoryConfiguration)` for example).
 
 
 

--- a/framework/architecture/history/migration.rst
+++ b/framework/architecture/history/migration.rst
@@ -17,7 +17,7 @@ The database has to be created as follows:
 - **Owner:** Must be equal to the database name (in the example above: ``nice_${CUSTOMER}`` example: nice_tocco).
 - **Password for the owner:** Same password as for the owner of the Nice database.
 
-Initializing the database can be done either by running the :java:ref:`HistoryDataStoreFragment<ch.tocco.nice2.persist.history.impl.store.HistoryDataStoreFragment>`
+Initializing the database can be done either by running the :abbr:`HistoryDataStoreFragment (ch.tocco.nice2.persist.history.impl.store.HistoryDataStoreFragment)`
 or by manually executing these statements:
 
 .. code:: sql

--- a/framework/configuration/acl.rst
+++ b/framework/configuration/acl.rst
@@ -71,7 +71,7 @@ This rule applies to all ``User`` entities.
     * ``and stop`` marks this rule as final (see above).
 
 .. note::
-    All security features are disabled when the ``privileged()`` invoker of the :java:ref:`SecurityManager<ch.tocco.nice2.security.SecurityManager>`
+    All security features are disabled when the ``privileged()`` invoker of the :abbr:`SecurityManager (ch.tocco.nice2.security.SecurityManager)`
     is used.
 
 Keywords
@@ -84,13 +84,13 @@ Also, the keyword ``permission`` is currently reserved, but unused.
 Security domains
 ----------------
 
-Different objects are secured with different :java:ref:`SecurityDomains<ch.tocco.nice2.security.spi.SecurityDomain>`. A security domain defines which permissions are
+Different objects are secured with different :abbr:`SecurityDomains (ch.tocco.nice2.security.spi.SecurityDomain)`. A security domain defines which permissions are
 available and how or if conditions can be applied to a rule.
 
 entityManager
 ^^^^^^^^^^^^^
 
-The target of this domain is an :java:ref:`EntityModel<ch.tocco.nice2.persist.model.EntityModel>`.
+The target of this domain is an :abbr:`EntityModel (ch.tocco.nice2.persist.model.EntityModel)`.
 It provides the ``create`` permission, which allows creating a new instance of an entity.
 Conditions are not supported.
 
@@ -156,7 +156,7 @@ entities are returned from the database.
 Updating relations
 ..................
 
-When an entity is added to or removed from a :java:ref:`Relation<ch.tocco.nice2.persist.entity.Relation>` the
+When an entity is added to or removed from a :abbr:`Relation (ch.tocco.nice2.persist.entity.Relation)` the
 permissions of the *both* sides of the relation are combined:
 
     * ``GRANT`` + ``GRANT`` = ``GRANT``
@@ -196,7 +196,7 @@ entity containing the field and not the field itself).
 This denies write access only to a single field of an entity (*email* in this case).
 
 These rules are checked whenever ``getValue()`` or ``setValue()`` (or a similar method like ``getString()``) is
-called on the :java:ref:`Entity<ch.tocco.nice2.persist.entity.Entity>`.
+called on the :abbr:`Entity (ch.tocco.nice2.persist.entity.Entity)`.
 
 .. note::
     When a user has been granted access to an entity (through the ``entity`` security domain) and there are no
@@ -256,16 +256,16 @@ Controls whether a specific report may be generated:
 Policy
 ------
 
-All ACL rules are compiled into a security :java:ref:`Policy<ch.tocco.nice2.security.Policy>`.
+All ACL rules are compiled into a security :abbr:`Policy (ch.tocco.nice2.security.Policy)`.
 The rules are applied in the order they were defined in the ``*.acl`` files (and depending on module
 dependencies). So it is always possible to override an earlier rule (unless ``and stop`` was defined
 on a rule).
 
-Because the full policy (stored in the :java:ref:`SecurityManager<ch.tocco.nice2.security.SecurityManager>`) for all possible principals and all possible objects may get very big for a full-scale application,
+Because the full policy (stored in the :abbr:`SecurityManager (ch.tocco.nice2.security.SecurityManager)`) for all possible principals and all possible objects may get very big for a full-scale application,
 this policy will be reduced whenever possible. There are two points, where some important facts get known that allow to filter out rules that won't apply anyway:
 
-    * After login, the exact principal is known. At this point, a new policy will be generated for that user (stored in the :java:ref:`SecurityContext<ch.tocco.nice2.security.SecurityContext>`) that doesn't contain any rules anymore that don't affect that principal.
-    * When a guard is needed, the exact object is known. At this point, all rules that don't affect this object will be filtered out using the selector (stored in the :java:ref:`Guard<ch.tocco.nice2.security.Guard>`).
+    * After login, the exact principal is known. At this point, a new policy will be generated for that user (stored in the :abbr:`SecurityContext (ch.tocco.nice2.security.SecurityContext)`) that doesn't contain any rules anymore that don't affect that principal.
+    * When a guard is needed, the exact object is known. At this point, all rules that don't affect this object will be filtered out using the selector (stored in the :abbr:`Guard (ch.tocco.nice2.security.Guard)`).
 
 Therefore, in practice, the policy for a concrete object will finally be relatively compact.
 
@@ -273,7 +273,7 @@ Checking permissions manually
 -----------------------------
 
 Normally the permissions are checked automatically when querying or updating data. But sometimes it is necessary
-to check permissions manually. This can be done by obtaining a :java:ref:`Guard<ch.tocco.nice2.security.Guard>` from
-the :java:ref:`SecurityContext<ch.tocco.nice2.security.SecurityContext>`.
-The :java:ref:`Guard<ch.tocco.nice2.security.Guard>` instance can then be used to evaluate permissions.
+to check permissions manually. This can be done by obtaining a :abbr:`Guard (ch.tocco.nice2.security.Guard)` from
+the :abbr:`SecurityContext (ch.tocco.nice2.security.SecurityContext)`.
+The :abbr:`Guard (ch.tocco.nice2.security.Guard)` instance can then be used to evaluate permissions.
 

--- a/framework/configuration/changesets.rst
+++ b/framework/configuration/changesets.rst
@@ -108,7 +108,7 @@ File resources in changesets
 There are moments when we need to write files to the database as initial values (mostly used to upload images used in
 report generation). This can be done by creating a changeset in version ``9.9.9.9`` (since the rest of the database must
 must be up to date for the DMS services to work) and using the custom change
-:java:ref:`AddEntityDocChange<ch.tocco.nice2.dbrefactoring.impl.liquibase.AddEntityDocChange>`. This custom change
+:abbr:`AddEntityDocChange (ch.tocco.nice2.dbrefactoring.impl.liquibase.AddEntityDocChange)`. This custom change
 then uploads the file to the DMS and sets the hash on the given entity.
 
 Working with Liquibase

--- a/framework/configuration/entity-listener.rst
+++ b/framework/configuration/entity-listener.rst
@@ -39,13 +39,13 @@ Additionally the module has to be imported in the file ``hivemodule.xml``
 CollectingEntityListener
 ------------------------
 
-Collecting entity listeners fetch all :java:ref:`EntityFacadeEvent<ch.tocco.nice2.persist.entity.events.EntityFacadeEvent>` until
+Collecting entity listeners fetch all :abbr:`EntityFacadeEvent (ch.tocco.nice2.persist.entity.events.EntityFacadeEvent)` until
 the current transaction is about to commit. This means a collecting entity listener is executed only once right before
-the commit. All :java:ref:`EntityFacadeEvents<ch.tocco.nice2.persist.entity.events.EntityFacadeEvent>` which are produced later,
+the commit. All :abbr:`EntityFacadeEvents (ch.tocco.nice2.persist.entity.events.EntityFacadeEvent)` which are produced later,
 for example by an other collecting entity listener which runs after the current, are discarded.
 
-To add a :java:ref:`CollectingEntityListener<ch.tocco.nice2.persist.util.CollectingEntityListener>` add a Java class which
-extends the class :java:ref:`CollectingEntityListener<ch.tocco.nice2.persist.util.CollectingEntityListener>`. Add the
+To add a :abbr:`CollectingEntityListener (ch.tocco.nice2.persist.util.CollectingEntityListener)` add a Java class which
+extends the class :abbr:`CollectingEntityListener (ch.tocco.nice2.persist.util.CollectingEntityListener)`. Add the
 class in the ``impl`` module where you working on. The method ``onBeforeCommit`` must be overwritten. This is the method
 which gets called by the nice2 framework just before the commit takes place.
 
@@ -70,8 +70,8 @@ The created listener must be registered as hivemind service in the file ``hivemo
 
 .. important::
    The service model must be ``threaded`` on collecting entity listeners (``model="threaded"``). This means that the service
-   is instantiated once per :java:ref:`Thread<java.lang.Thread>` and bound to this :java:ref:`Thread<java.lang.Thread>`
-   only. This is needed because the collecting entity listener fetches every :java:ref:`EntityFacadeEvent<ch.tocco.nice2.persist.entity.events.EntityFacadeEvent>`
+   is instantiated once per :abbr:`Thread (java.lang.Thread)` and bound to this :abbr:`Thread (java.lang.Thread)`
+   only. This is needed because the collecting entity listener fetches every :abbr:`EntityFacadeEvent (ch.tocco.nice2.persist.entity.events.EntityFacadeEvent)`
    of one transaction only. For more information about hivemind service models see `Threaded Service Model`_.
 
 Now the service needs to be contributed as Listener. With the contribution also the entity model on which the listener
@@ -97,8 +97,8 @@ be contributed as listener.
 Handle Events
 ^^^^^^^^^^^^^
 
-The class :java:ref:`CollectingEntityListener<ch.tocco.nice2.persist.util.CollectingEntityListener>` provides some useful
-methods to handle the :java:ref:`EntityFacadeEvents<ch.tocco.nice2.persist.history.impl.tasks.FacadeEvent>` correctly.
+The class :abbr:`CollectingEntityListener (ch.tocco.nice2.persist.util.CollectingEntityListener)` provides some useful
+methods to handle the :abbr:`EntityFacadeEvents (ch.tocco.nice2.persist.history.impl.tasks.FacadeEvent)` correctly.
 The most important methods are described here. Open the class ``ch.tocco.nice2.persist.util.CollectingEntityListener`` to
 see all methods.
 
@@ -195,7 +195,7 @@ model which the listener was contributed to listen to.
 Using the ``Context`` in Collecting Entity Listeners
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The context can be received by the :java:ref:`Transaction<ch.tocco.nice2.persist.tx.Transaction>` passed to the
+The context can be received by the :abbr:`Transaction (ch.tocco.nice2.persist.tx.Transaction)` passed to the
 ``onBeforeCommit`` method.
 
 .. code-block:: Java
@@ -209,8 +209,8 @@ The context can be received by the :java:ref:`Transaction<ch.tocco.nice2.persist
    }
 
 .. important::
-   Do not inject the :java:ref:`Context<ch.tocco.nice2.persist.Context>` in a CollectingEntityListener but get it from
-   the passed :java:ref:`Transaction<ch.tocco.nice2.persist.tx.Transaction>`
+   Do not inject the :abbr:`Context (ch.tocco.nice2.persist.Context)` in a CollectingEntityListener but get it from
+   the passed :abbr:`Transaction (ch.tocco.nice2.persist.tx.Transaction)`
 
 The Order of Collecting Entity Listeners
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -232,20 +232,20 @@ listener does not process the user created by the second listener.
 InterruptibleEntityFacadeAdapter
 --------------------------------
 
-An :java:ref:`InterruptibleEntityFacadeAdapter<ch.tocco.nice2.persist.entity.events.InterruptibleEntityFacadeAdapter>` is
-executed for every :java:ref:`EntityFacadeEvent<ch.tocco.nice2.persist.history.impl.tasks.FacadeEvent>` which belongs to
+An :abbr:`InterruptibleEntityFacadeAdapter (ch.tocco.nice2.persist.entity.events.InterruptibleEntityFacadeAdapter)` is
+executed for every :abbr:`EntityFacadeEvent (ch.tocco.nice2.persist.history.impl.tasks.FacadeEvent)` which belongs to
 the entity on which the listener is contributed to listen to. This means every time ``setValue`` or a similar method
-is called on the entity the :java:ref:`InterruptibleEntityFacadeAdapter<ch.tocco.nice2.persist.entity.events.InterruptibleEntityFacadeAdapter>`
+is called on the entity the :abbr:`InterruptibleEntityFacadeAdapter (ch.tocco.nice2.persist.entity.events.InterruptibleEntityFacadeAdapter)`
 is executed.
 
 .. note::
-   The :java:ref:`InterruptibleEntityFacadeAdapter<ch.tocco.nice2.persist.entity.events.InterruptibleEntityFacadeAdapter>`
-   is almost the same as the :java:ref:`EntityFacadeListener<ch.tocco.nice2.persist.entity.events.EntityFacadeListener>`
+   The :abbr:`InterruptibleEntityFacadeAdapter (ch.tocco.nice2.persist.entity.events.InterruptibleEntityFacadeAdapter)`
+   is almost the same as the :abbr:`EntityFacadeListener (ch.tocco.nice2.persist.entity.events.EntityFacadeListener)`
    but handles rolled-back transactions and InterruptedExceptions itself. Always use the
-   :java:ref:`InterruptibleEntityFacadeAdapter<ch.tocco.nice2.persist.entity.events.InterruptibleEntityFacadeAdapter>` if
+   :abbr:`InterruptibleEntityFacadeAdapter (ch.tocco.nice2.persist.entity.events.InterruptibleEntityFacadeAdapter)` if
    there is not a good reason to not use it.
 
-To add a :java:ref:`InterruptibleEntityFacadeAdapter<ch.tocco.nice2.persist.entity.events.InterruptibleEntityFacadeAdapter>`
+To add a :abbr:`InterruptibleEntityFacadeAdapter (ch.tocco.nice2.persist.entity.events.InterruptibleEntityFacadeAdapter)`
 add a Java class which extends the class. Add the class in the ``impl`` module where you working on.
 
 .. code-block:: Java
@@ -352,13 +352,13 @@ on ``Users`` if they're older than 18 years. This could be done like this:
    }
 
 This would work without any problems. But most probably this listener would be executed a lot of times even it would not
-be necessary. Because :java:ref:`InterruptibleEntityFacadeAdapters<ch.tocco.nice2.persist.entity.events.InterruptibleEntityFacadeAdapter>`
+be necessary. Because :abbr:`InterruptibleEntityFacadeAdapters (ch.tocco.nice2.persist.entity.events.InterruptibleEntityFacadeAdapter)`
 are executed every time ``setValue`` is called on the entity, this listener is also executed if for example only the name
 of the user was changed. The name has nothing to do with the age of user.
 
-A :java:ref:`EntityChangedEvent<ch.tocco.nice2.persist.entity.events.EntityChangedEvent>` is passed to the method
+A :abbr:`EntityChangedEvent (ch.tocco.nice2.persist.entity.events.EntityChangedEvent)` is passed to the method
 ``entityChangingInterruptible`` which has some additional methods over the
-:java:ref:`EntityFacadeEvent<ch.tocco.nice2.persist.entity.events.EntityFacadeEvent>` to work with. The above example
+:abbr:`EntityFacadeEvent (ch.tocco.nice2.persist.entity.events.EntityFacadeEvent)` to work with. The above example
 can be rewritten to the following:
 
 .. code-block:: Java
@@ -380,8 +380,8 @@ can be rewritten to the following:
 Before the whole logic (setting the adult flag) is processed, we check if the change which is done to the entity belongs to
 the field ``brithdate`` because this is the only field which is relevant for this listener. Then instead of reading the
 field ``birthdate`` from the entity we just call the method ``getNewValue`` on the
-A :java:ref:`EntityChangedEvent<ch.tocco.nice2.persist.entity.events.EntityChangedEvent>`. Because ``getNewValue`` returns
-an :java:ref:`Object<java.lang.Object>` it needs to be casted first.
+A :abbr:`EntityChangedEvent (ch.tocco.nice2.persist.entity.events.EntityChangedEvent)`. Because ``getNewValue`` returns
+an :abbr:`Object (java.lang.Object)` it needs to be casted first.
 
 entityRelationChangingInterruptible
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -402,13 +402,13 @@ This method gets called if a relation on the entity was changed.
 EntityRelationChangedEvent
 ++++++++++++++++++++++++++
 
-A :java:ref:`EntityRelationChangedEvent<ch.tocco.nice2.persist.entity.events.EntityRelationChangedEvent>` is passed to
+A :abbr:`EntityRelationChangedEvent (ch.tocco.nice2.persist.entity.events.EntityRelationChangedEvent)` is passed to
 the method ``entityRelationChangingInterruptible`` which has some additional methods over the
-:java:ref:`EntityFacadeEvent<ch.tocco.nice2.persist.entity.events.EntityFacadeEvent>` to work with.
+:abbr:`EntityFacadeEvent (ch.tocco.nice2.persist.entity.events.EntityFacadeEvent)` to work with.
 
 
 To check what relation was changed the method ``getRelation`` can get called on the
-:java:ref:`EntityRelationChangedEvent<ch.tocco.nice2.persist.entity.events.EntityRelationChangedEvent>`.
+:abbr:`EntityRelationChangedEvent (ch.tocco.nice2.persist.entity.events.EntityRelationChangedEvent)`.
 
 .. code-block:: Java
 
@@ -447,7 +447,7 @@ There also methods to check how the relation got changed.
 Using the ``Context`` in Entity Facade Listeners
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The context can be received by the :java:ref:`EntityFacadeEvent<ch.tocco.nice2.persist.entity.events.EntityFacadeEvent>`
+The context can be received by the :abbr:`EntityFacadeEvent (ch.tocco.nice2.persist.entity.events.EntityFacadeEvent)`
 passed to the overwritten methods.
 
 .. code-block:: Java
@@ -460,14 +460,14 @@ passed to the overwritten methods.
    }
 
 .. important::
-   Do not inject the :java:ref:`Context<ch.tocco.nice2.persist.Context>` in a
-   :java:ref:`InterruptibleEntityFacadeAdapter<ch.tocco.nice2.persist.entity.events.InterruptibleEntityFacadeAdapter>`
+   Do not inject the :abbr:`Context (ch.tocco.nice2.persist.Context)` in a
+   :abbr:`InterruptibleEntityFacadeAdapter (ch.tocco.nice2.persist.entity.events.InterruptibleEntityFacadeAdapter)`
    but get it from the source entity.
 
 Avoid Infinite Loops
 ^^^^^^^^^^^^^^^^^^^^
 
-With :java:ref:`InterruptibleEntityFacadeAdapters<ch.tocco.nice2.persist.entity.events.InterruptibleEntityFacadeAdapter>`
+With :abbr:`InterruptibleEntityFacadeAdapters (ch.tocco.nice2.persist.entity.events.InterruptibleEntityFacadeAdapter)`
 it is possible to create infinite loops. Because these listeners are executed every time a change has made to the entity
 which the listener listens to. In the picture below an example of an infinite loop is shown (example does not make any
 sense).
@@ -481,12 +481,12 @@ sets a value on the field ``lastname``. Listener ``B`` listens to the field ``la
 CollectingAfterCommitListener
 -----------------------------
 
-:java:ref:`CollectingAfterCommitListeners<ch.tocco.nice2.persist.util.CollectingAfterCommitListener>` are fired after the
+:abbr:`CollectingAfterCommitListeners (ch.tocco.nice2.persist.util.CollectingAfterCommitListener)` are fired after the
 transaction was committed. This can be useful if something only must be done if something else was persisted before.
-For example mails are sent often with :java:ref:`CollectingAfterCommitListeners<ch.tocco.nice2.persist.util.CollectingAfterCommitListener>`.
+For example mails are sent often with :abbr:`CollectingAfterCommitListeners (ch.tocco.nice2.persist.util.CollectingAfterCommitListener)`.
 Lets say a user should receive an e-mail if he was registered to an event. This could be done within a
-:java:ref:`InterruptibleEntityFacadeAdapter<ch.tocco.nice2.persist.entity.events.InterruptibleEntityFacadeAdapter>` or
-:java:ref:`CollectingEntityListener<ch.tocco.nice2.persist.util.CollectingEntityListener>`.
+:abbr:`InterruptibleEntityFacadeAdapter (ch.tocco.nice2.persist.entity.events.InterruptibleEntityFacadeAdapter)` or
+:abbr:`CollectingEntityListener (ch.tocco.nice2.persist.util.CollectingEntityListener)`.
 
 .. code-block:: Java
 
@@ -502,11 +502,11 @@ Lets say a user should receive an e-mail if he was registered to an event. This 
 But if the current transaction for some reason fails, it will be rolled back and the registration entity is not persisted.
 In this case the user would have received an e-mail but was not actually registered to the event.
 
-That is when :java:ref:`CollectingAfterCommitListeners<ch.tocco.nice2.persist.util.CollectingAfterCommitListener>` are
+That is when :abbr:`CollectingAfterCommitListeners (ch.tocco.nice2.persist.util.CollectingAfterCommitListener)` are
 useful.
 
-:java:ref:`CollectingAfterCommitListeners<ch.tocco.nice2.persist.util.CollectingAfterCommitListener>` need to be registered
-and contributed as listener the same way as :java:ref:`CollectingEntityListener<ch.tocco.nice2.persist.util.CollectingEntityListener>`
+:abbr:`CollectingAfterCommitListeners (ch.tocco.nice2.persist.util.CollectingAfterCommitListener)` need to be registered
+and contributed as listener the same way as :abbr:`CollectingEntityListener (ch.tocco.nice2.persist.util.CollectingEntityListener)`
 are.
 
 .. code-block:: XML
@@ -525,8 +525,8 @@ are.
 
 
 The listener must extend the class
-:java:ref:`CollectingAfterCommitListener<ch.tocco.nice2.persist.util.CollectingAfterCommitListener>` and overwrite the
-method ``getAfterCommitTask`` which returns an :java:ref:`AfterCommitTask<ch.tocco.nice2.persist.util.AfterCommitTask>`.
+:abbr:`CollectingAfterCommitListener (ch.tocco.nice2.persist.util.CollectingAfterCommitListener)` and overwrite the
+method ``getAfterCommitTask`` which returns an :abbr:`AfterCommitTask (ch.tocco.nice2.persist.util.AfterCommitTask)`.
 
 
 .. code-block:: Java
@@ -548,7 +548,7 @@ method ``getAfterCommitTask`` which returns an :java:ref:`AfterCommitTask<ch.toc
    }
 
 .. note::
-   A :java:ref:`CollectingAfterCommitListener<ch.tocco.nice2.persist.util.CollectingAfterCommitListener>` does not know
+   A :abbr:`CollectingAfterCommitListener (ch.tocco.nice2.persist.util.CollectingAfterCommitListener)` does not know
    what has changed on the entities itself. But if the entity got created, updated or deleted is known.
 
 .. _Threaded Service Model: https://hivemind.apache.org/hivemind1/services.html#Threaded+Service+Model

--- a/framework/configuration/initial-values.rst
+++ b/framework/configuration/initial-values.rst
@@ -174,14 +174,14 @@ Running initial values from changesets
 --------------------------------------
 
 It is possible to run specific initial values from changeset through the use of the
-:java:ref:`YamlInitialValueCustomChange<ch.tocco.nice2.dbrefactoring.impl.data.YamlInitialValueCustomChange>`. See the
+:abbr:`YamlInitialValueCustomChange (ch.tocco.nice2.dbrefactoring.impl.data.YamlInitialValueCustomChange)`. See the
 class for instructions how to use it, but make sure that you actually need to use it since it is a rather ugly fix for
 necessary interactions between existing changesets and new initial values.
 
 Migrating changesets to YAML initial values
 -------------------------------------------
 
-There is a action called :java:ref:`YamlLookupAction<ch.tocco.nice2.dbrefactoring.impl.yaml.YamlLookupAction>` that can
+There is a action called :abbr:`YamlLookupAction (ch.tocco.nice2.dbrefactoring.impl.yaml.YamlLookupAction)` that can
 be called directly by a developer. This will find all initial value changesets in the installed modules and will try to
 map them to new YAML initial values. It is not super cleanly implemented since it was mainly used to support a manual
 migration, so the results need to be checked carefully. But in general, most customers will not need to migrate their

--- a/framework/configuration/reports.rst
+++ b/framework/configuration/reports.rst
@@ -116,7 +116,7 @@ the synchronization synchronizes this entity again.
 Starting the Report Synchronization
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The report synchronization is done with the :java:ref:`ReportSynchronizer<ch.tocco.nice2.reporting.impl.sync.ReportSynchronizer>`
+The report synchronization is done with the :abbr:`ReportSynchronizer (ch.tocco.nice2.reporting.impl.sync.ReportSynchronizer)`
 service. This service is registered as ``starter`` but synchronizes the entities only in the ``RunEnv`` mode
 ``production`` and ``test`` during the start up.
 

--- a/framework/configuration/rest-resource.rst
+++ b/framework/configuration/rest-resource.rst
@@ -20,9 +20,9 @@ resources.
 
 The steps to implement a REST resource in any module:
     #. Add the required Maven dependency
-    #. Extend the Java interface :java:ref:`ch.tocco.nice2.rest.core.spi.RestResource` and define
+    #. Extend the Java interface :abbr:`ch.tocco.nice2.rest.core.spi.RestResource (RestResource)` and define
        your methods and the corresponding JAX-RS annotations.
-    #. Implement your interface (by also extending the class :java:ref:`ch.tocco.nice2.rest.core.spi.AbstractRestResource`)
+    #. Implement your interface (by also extending the class :abbr:`ch.tocco.nice2.rest.core.spi.AbstractRestResource (AbstractRestResource)`)
     #. Register your REST resource in the ``hivemodule.xml`` of the module.
 
 The following paragraphs explain in detail how this is done.
@@ -68,7 +68,7 @@ Additionally the module ``ch.tocco.nice2.rest.core.spi`` has to be imported in t
 Create Java interface
 ---------------------
 
-Create the Java interface for your resource by extending :java:ref:`ch.tocco.nice2.rest.core.spi.RestResource`.
+Create the Java interface for your resource by extending :abbr:`ch.tocco.nice2.rest.core.spi.RestResource (RestResource)`.
 
 The following interface defines a REST resource which will be available on ``${BASE_PATH}/events/{city}``.
 It defines a method called ``getEvents()`` and a second method ``addEvent()``. The first method is mapped to
@@ -172,7 +172,7 @@ Implement resource
 ------------------
 
 Add the implementation for your resource by implementing your created interface and extending
-:java:ref:`ch.tocco.nice2.rest.core.spi.AbstractRestResource`.
+:abbr:`ch.tocco.nice2.rest.core.spi.AbstractRestResource (AbstractRestResource)`.
 
 .. code-block:: Java
 
@@ -191,7 +191,7 @@ Add the implementation for your resource by implementing your created interface 
 How to test your resource
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Test your resource by extending :java:ref:`ch.tocco.nice2.rest.testlib.AbstractInjectingJerseyTestCase`. Writing
+Test your resource by extending :abbr:`ch.tocco.nice2.rest.testlib.AbstractInjectingJerseyTestCase (AbstractInjectingJerseyTestCase)`. Writing
 tests for your resource by extending this base class allows you to implement **end-to-end** tests which test the
 whole process including routing (via JAX-RS annotations on your interface) and error handling (via the exception
 mappers you contribute in the test).
@@ -201,9 +201,9 @@ mappers you contribute in the test).
    Compared to simple unit tests, this is the preferred way to test your resource. However, lower level unit tests
    are important as well.
 
-Set up your test like any conventional :java:ref:`ch.tocco.nice2.persist.testlib.inject.AbstractInjectingTestCase`
-and additionally implement the abstract method :java:ref:`getRestResources():List<?>` and optionally
-:java:ref:`getExceptionMappers():List<ExceptionMapper>` to test error handling.
+Set up your test like any conventional :abbr:`ch.tocco.nice2.persist.testlib.inject.AbstractInjectingTestCase (AbstractInjectingTestCase)`
+and additionally implement the abstract method ``getRestResources():List<?>`` and optionally
+``getExceptionMappers():List<ExceptionMapper>`` to test error handling.
 
 First add the required test dependency in your ``pom.xml``:
 
@@ -274,11 +274,11 @@ Then add your test class(es):
 
    **NO** 
 
-   :java:ref:`Response response = target("/location/suggestions?city=Züri").get();`
+   ``Response response = target("/location/suggestions?city=Züri").get();``
 
    **YES** 
 
-   :java:ref:`Response response = target("/location/suggestions").queryParam("city", "Züri").request().get();`
+   ``Response response = target("/location/suggestions").queryParam("city", "Züri").request().get();``
 
    
 

--- a/framework/configuration/rest-resource.rst
+++ b/framework/configuration/rest-resource.rst
@@ -20,9 +20,9 @@ resources.
 
 The steps to implement a REST resource in any module:
     #. Add the required Maven dependency
-    #. Extend the Java interface :abbr:`ch.tocco.nice2.rest.core.spi.RestResource (RestResource)` and define
+    #. Extend the Java interface :abbr:`RestResource (ch.tocco.nice2.rest.core.spi.RestResource)` and define
        your methods and the corresponding JAX-RS annotations.
-    #. Implement your interface (by also extending the class :abbr:`ch.tocco.nice2.rest.core.spi.AbstractRestResource (AbstractRestResource)`)
+    #. Implement your interface (by also extending the class :abbr:`AbstractRestResource (ch.tocco.nice2.rest.core.spi.AbstractRestResource)`)
     #. Register your REST resource in the ``hivemodule.xml`` of the module.
 
 The following paragraphs explain in detail how this is done.
@@ -68,7 +68,7 @@ Additionally the module ``ch.tocco.nice2.rest.core.spi`` has to be imported in t
 Create Java interface
 ---------------------
 
-Create the Java interface for your resource by extending :abbr:`ch.tocco.nice2.rest.core.spi.RestResource (RestResource)`.
+Create the Java interface for your resource by extending :abbr:`RestResource (ch.tocco.nice2.rest.core.spi.RestResource)`.
 
 The following interface defines a REST resource which will be available on ``${BASE_PATH}/events/{city}``.
 It defines a method called ``getEvents()`` and a second method ``addEvent()``. The first method is mapped to
@@ -172,7 +172,7 @@ Implement resource
 ------------------
 
 Add the implementation for your resource by implementing your created interface and extending
-:abbr:`ch.tocco.nice2.rest.core.spi.AbstractRestResource (AbstractRestResource)`.
+:abbr:`AbstractRestResource (ch.tocco.nice2.rest.core.spi.AbstractRestResource)`.
 
 .. code-block:: Java
 
@@ -191,7 +191,7 @@ Add the implementation for your resource by implementing your created interface 
 How to test your resource
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Test your resource by extending :abbr:`ch.tocco.nice2.rest.testlib.AbstractInjectingJerseyTestCase (AbstractInjectingJerseyTestCase)`. Writing
+Test your resource by extending :abbr:`AbstractInjectingJerseyTestCase (ch.tocco.nice2.rest.testlib.AbstractInjectingJerseyTestCase)`. Writing
 tests for your resource by extending this base class allows you to implement **end-to-end** tests which test the
 whole process including routing (via JAX-RS annotations on your interface) and error handling (via the exception
 mappers you contribute in the test).
@@ -201,7 +201,7 @@ mappers you contribute in the test).
    Compared to simple unit tests, this is the preferred way to test your resource. However, lower level unit tests
    are important as well.
 
-Set up your test like any conventional :abbr:`ch.tocco.nice2.persist.testlib.inject.AbstractInjectingTestCase (AbstractInjectingTestCase)`
+Set up your test like any conventional :abbr:`AbstractInjectingTestCase (ch.tocco.nice2.persist.testlib.inject.AbstractInjectingTestCase)`
 and additionally implement the abstract method ``getRestResources():List<?>`` and optionally
 ``getExceptionMappers():List<ExceptionMapper>`` to test error handling.
 

--- a/framework/modules/calendar.rst
+++ b/framework/modules/calendar.rst
@@ -45,11 +45,11 @@ Listeners
 ---------
 There are three listeners that are responsible to keep all ``Calendar_event`` entities up-to-date.
 
-* :java:ref:`GenericCalendarEventListener<ch.tocco.nice2.optional.calendar.impl.entitylistener.calendarevent.GenericCalendarEventListener>`
+* :abbr:`GenericCalendarEventListener (ch.tocco.nice2.optional.calendar.impl.entitylistener.calendarevent.GenericCalendarEventListener)`
   generates ``Calendar_event`` entities for system calendars.
-* :java:ref:`EntityCalendarEventListener<ch.tocco.nice2.optional.calendar.impl.entitylistener.calendarevent.EntityCalendarEventListener>`
+* :abbr:`EntityCalendarEventListener (ch.tocco.nice2.optional.calendar.impl.entitylistener.calendarevent.EntityCalendarEventListener)`
   generates ``Calendar_event`` entities for entity-specific calendars.
-* :java:ref:`OfftimeEventMappingEntityListener<ch.tocco.nice2.optional.conflict.impl.OfftimeEventMappingEntityListener>`
+* :abbr:`OfftimeEventMappingEntityListener (ch.tocco.nice2.optional.conflict.impl.OfftimeEventMappingEntityListener)`
   creates ``Calendar_event`` entities for ``Offtime_event`` entities. If the ``Offtime_event`` has no related
   ``Calendar`` the ``Calendar_event`` entities are created in every existing ``Calendar``.
 
@@ -63,11 +63,11 @@ In addition, there are four contributions to ``nice2.entityoperation.CascadingDe
 Conflict
 --------
 ``Conflict`` entities are related to two ``Calendar_event`` entities in the same calendar which overlap. These are
-created in :java:ref:`CreateConflictEntityListener<ch.tocco.nice2.optional.conflict.impl.entitylistener.CreateConflictEntityListener>`.
+created in :abbr:`CreateConflictEntityListener (ch.tocco.nice2.optional.conflict.impl.entitylistener.CreateConflictEntityListener)`.
 Since ``Calendar_event`` entities are only recreated or deleted there are no listeners that update or delete ``Conflict``
 entities, they are just cascade deleted with their ``Calendar_event`` entities.
 
-:java:ref:`SetConflictsStatusListener<ch.tocco.nice2.optional.conflict.impl.entitylistener.SetConflictsStatusListener>`
+:abbr:`SetConflictsStatusListener (ch.tocco.nice2.optional.conflict.impl.entitylistener.SetConflictsStatusListener)`
 sets ``Conflict_status`` on ``Registration``, ``Lecturer_booking`` and ``Reservation``, depending on the existence
 of ``Conflict`` entities related to them.
 

--- a/framework/modules/drools/drools_educationrequirement.rst
+++ b/framework/modules/drools/drools_educationrequirement.rst
@@ -40,6 +40,6 @@ RequirementStatusUtil
 
 This class is used to set the status of the ``Requirement`` that is being evaluated. Additional reasons for the
 for the activation of this rule can be passed to it through the
-:java:ref:`addReason<ch.tocco.nice2.optional.educationrequirement.impl.requirementevaluation.globals.RequirementStatusUtil#addReason>`
+:abbr:`addReason (ch.tocco.nice2.optional.educationrequirement.impl.requirementevaluation.globals.RequirementStatusUtil#addReason)`
 method and the
-:java:ref:`Reason<ch.tocco.nice2.optional.educationrequirement.impl.requirementevaluation.globals.Reason>` class.
+:abbr:`Reason (ch.tocco.nice2.optional.educationrequirement.impl.requirementevaluation.globals.Reason)` class.

--- a/framework/modules/drools/drools_qualification.rst
+++ b/framework/modules/drools/drools_qualification.rst
@@ -19,8 +19,8 @@ Node
 ^^^^
 
 This represents a node in the qualification structure. It can be either a
-:java:ref:`EvalNode<ch.tocco.nice2.optional.qualification.impl.drools.facts.qs.EvalNode>`, wrapping a
-``Evaluation_node``, or a :java:ref:`RatingNode<ch.tocco.nice2.optional.qualification.impl.drools.facts.qs.RatingNode>`,
+:abbr:`EvalNode (ch.tocco.nice2.optional.qualification.impl.drools.facts.qs.EvalNode)`, wrapping a
+``Evaluation_node``, or a :abbr:`RatingNode (ch.tocco.nice2.optional.qualification.impl.drools.facts.qs.RatingNode)`,
 wrapping a ``Input_node``.
 
 Grade

--- a/framework/rest/swagger-integration/index.rst
+++ b/framework/rest/swagger-integration/index.rst
@@ -42,11 +42,11 @@ with ``href="swagger/swagger-ui.css"``
 2. NiceOpenApiServlet
 ^^^^^^^^^^^^^^^^^^^^^
 
-The :java:ref:`NiceOpenApiServlet<ch.tocco.nice2.rest.doc.impl.NiceOpenApiServlet>` extends the
-:java:ref:`OpenApiServlet<io.swagger.v3.jaxrs2.integration.OpenApiServlet>` which produces the `OpenAPI Specification`_
+The :abbr:`NiceOpenApiServlet (ch.tocco.nice2.rest.doc.impl.NiceOpenApiServlet)` extends the
+:abbr:`OpenApiServlet (io.swagger.v3.jaxrs2.integration.OpenApiServlet)` which produces the `OpenAPI Specification`_
 for the Swagger-UI page.
 
-In the :java:ref:`NiceOpenApiServlet<ch.tocco.nice2.rest.doc.impl.NiceOpenApiServlet>` the following is configured:
+In the :abbr:`NiceOpenApiServlet (ch.tocco.nice2.rest.doc.impl.NiceOpenApiServlet)` the following is configured:
  - All REST resources
  - Some information like the company and contact data
  - The authentication mechanism (so that authenticated requests can be executed)
@@ -57,7 +57,7 @@ The serlvet can be requested under ``<INSTALLATION>/nice2/openapi``.
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To describe the REST resources `Swagger Annotations`_ are used. The
-:java:ref:`NiceOpenApiServlet<ch.tocco.nice2.rest.doc.impl.NiceOpenApiServlet>` converts these to the `OpenAPI Specification`_.
+:abbr:`NiceOpenApiServlet (ch.tocco.nice2.rest.doc.impl.NiceOpenApiServlet)` converts these to the `OpenAPI Specification`_.
 
 Check the `Swagger Annotation docs`_ to see how resources can be described.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-javasphinx
+# Read the Docs mandates this file to be present


### PR DESCRIPTION
### Description

Javasphinx has been removed and replaced by extlinks (first commit). The changes to the *.rst files themselves (second commit) have been done via [script](https://github.com/pgerber/devops-docs/commit/3a1f6bc4079c19b1c23841f885a080ce8e558724), it contains a few comment to explain what is replaced by what. A rendered version of this change is available as [*next* version](https://tocco-docs.readthedocs.io/en/next/).

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is **ready to be merged** as is
- [x] I verified the modifications **render properly**
- [x] I used **spell checking**
- [x] I **used the styling and structure aids available** in [Sphinx/ResT](http://www.sphinx-doc.org/en/stable/rest.html). (Links use `` `…`_``, enumerations `#.`, lists `*`, code ``` ``…`` ```/`.. code::`, warnings .. `warning::`, etc.)
- [x] I reread the text keeping in mind that the text has to be **comprehended** fully **by the target audience**