### PR TITLE
Stop truncating tables vertically on large screens

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -39,7 +39,17 @@ pre.literal-block {
  color: black;
      background: #fc888a;
 }
+
 .deprecated > .admonition-title {
      background: #d67173 !important;
+}
 
+/* We do not want tables to be arbitrarily truncated after 800px forcing people to scroll sideways … */
+.wy-nav-content {
+  max-width: none;
+}
+
+/* … but we still want text to be wrapped. */
+p {
+  max-width: 800px;
 }


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is **ready to be merged** as is
- [x] I verified the modifications **render properly**
- [x] I used **spell checking**
- [x] I **used the styling and structure aids available** in [Sphinx/ResT](http://www.sphinx-doc.org/en/stable/rest.html). (Links use `` `…`_``, enumerations `#.`, lists `*`, code ``` ``…`` ```/`.. code::`, warnings .. `warning::`, etc.)
- [x] I reread the text keeping in mind that the text has to be **comprehended** fully **by the target audience**

### Description
<!-- brief description of the changes you made -->
